### PR TITLE
chore(CI): Cache css-in-js files

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -28,6 +28,16 @@ jobs:
       - run: yarn install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v2
+        id: css-in-js-cache
+        name: Cache css in js files
+        with:
+          path: |
+            packages/module/src/css/*.(t|j|mj)s
+          key: ${{ runner.os }}-css-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('packages/module/src/css/*') }}
+      - name: generate
+        run: cd packages/module && yarn generate
+        if: steps.css-in-js-cache.outputs.cache-hit != 'true'
+      - uses: actions/cache@v2
         id: dist
         name: Cache dist
         with:
@@ -102,12 +112,21 @@ jobs:
       - run: yarn install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v2
+        id: css-in-js-cache
+        name: Cache css in js files
+        with:
+          path: |
+            packages/module/src/css
+          key: ${{ runner.os }}-css-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('packages/module/src/css/*') }}
+      - name: generate
+        run: cd packages/module && yarn generate
+        if: steps.css-in-js-cache.outputs.cache-hit != 'true'
+      - uses: actions/cache@v2
         id: dist
         name: Cache dist
         with:
           path: |
             packages/*/dist
-            packages/react-styles/css
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build
@@ -143,12 +162,21 @@ jobs:
       - run: yarn install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v2
+        id: css-in-js-cache
+        name: Cache css in js files
+        with:
+          path: |
+            packages/module/src/css
+          key: ${{ runner.os }}-css-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('packages/module/src/css/*') }}
+      - name: generate
+        run: cd packages/module && yarn generate
+        if: steps.css-in-js-cache.outputs.cache-hit != 'true'
+      - uses: actions/cache@v2
         id: dist
         name: Cache dist
         with:
           path: |
             packages/*/dist
-            packages/react-styles/css
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,21 @@ jobs:
       - run: yarn install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v2
+        id: css-in-js-cache
+        name: Cache css in js files
+        with:
+          path: |
+            packages/module/src/css
+          key: ${{ runner.os }}-css-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('packages/module/src/css/*') }}
+      - name: generate
+        run: cd packages/module && yarn generate
+        if: steps.css-in-js-cache.outputs.cache-hit != 'true'
+      - uses: actions/cache@v2
         id: dist
         name: Cache dist
         with:
           path: |
             packages/*/dist
-            packages/react-styles/css
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build
@@ -98,12 +107,21 @@ jobs:
       - run: yarn install --frozen-lockfile
         if: steps.yarn-cache.outputs.cache-hit != 'true'
       - uses: actions/cache@v2
+        id: css-in-js-cache
+        name: Cache css in js files
+        with:
+          path: |
+            packages/module/src/css
+          key: ${{ runner.os }}-css-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('packages/module/src/css/*') }}
+      - name: generate
+        run: cd packages/module && yarn generate
+        if: steps.css-in-js-cache.outputs.cache-hit != 'true'
+      - uses: actions/cache@v2
         id: dist
         name: Cache dist
         with:
           path: |
             packages/*/dist
-            packages/react-styles/css
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build


### PR DESCRIPTION
Fixes the current CI error by caching generated css-in-js module files in addition to the dist directory.