### PR TITLE
fix(pipelines): Set dimensions on spacer nodes

### DIFF
--- a/packages/module/src/pipelines/utils/utils.ts
+++ b/packages/module/src/pipelines/utils/utils.ts
@@ -95,7 +95,9 @@ export const getSpacerNodes = (
   Object.keys(multiParallelToParallelList).forEach(key => {
     spacerNodes.push({
       id: key,
-      type: spacerNodeType
+      type: spacerNodeType,
+      width: 1,
+      height: 1
     });
   });
 


### PR DESCRIPTION
## What
Closes https://github.com/patternfly/react-topology/issues/32

## Description
Set a width and height on spacer nodes so that they are not ignored by the layout.

## Type of change
- [x] Bugfix
