### PR TITLE
fix(css): Add the CSS js files to the npm package

### DIFF
--- a/packages/module/src/css/.npmignore
+++ b/packages/module/src/css/.npmignore
@@ -1,0 +1,1 @@
+# empty so all files get released

--- a/packages/module/src/utils/style-utils.ts
+++ b/packages/module/src/utils/style-utils.ts
@@ -1,5 +1,5 @@
 import { EdgeAnimationSpeed, EdgeStyle, NodeStatus } from '../types';
-import styles from '@patternfly/react-topology/dist/esm/css/topology-components';
+import styles from '../css/topology-components';
 
 export const StatusModifier = {
   [NodeStatus.default]: '',


### PR DESCRIPTION
## What
Closes https://github.com/patternfly/react-topology/issues/35

## Description
CSS js files are being ignored by .gitignore and hence excluded from the NPM package.
Add a .npmignore file to override .gitignore for NPM

## Type of change
- [x] Build related changes
