### PR TITLE
Fix integralShapePath for almost parallel nodes

### DIFF
--- a/packages/demo-app-ts/src/App.tsx
+++ b/packages/demo-app-ts/src/App.tsx
@@ -6,7 +6,6 @@ import {
   NavList,
   NavItem,
   PageSection,
-  SkipToContent,
   PageSidebar,
   Avatar,
   Brand,
@@ -112,7 +111,6 @@ class App extends React.Component<{}, AppState> {
   };
 
   private pageId = 'ts-demo-app-page-id';
-  private getSkipToContentLink = () => <SkipToContent href={`#${this.pageId}`}>Skip to Content</SkipToContent>;
 
   render() {
     const { isNavOpen, activeItem, isDarkTheme } = this.state;
@@ -191,7 +189,6 @@ class App extends React.Component<{}, AppState> {
         <Page
           header={AppHeader}
           sidebar={AppSidebar}
-          skipToContent={this.getSkipToContentLink()}
           isManagedSidebar
           mainContainerId={this.pageId}
         >

--- a/packages/demo-app-ts/src/Demo.css
+++ b/packages/demo-app-ts/src/Demo.css
@@ -6,8 +6,8 @@
 }
 
 .pf-ri__topology-demo .pf-topology-visualization-surface {
-  margin-top: var(--pf-global--spacer--md);
   border: 1px solid var(--pf-global--BorderColor--100);
+  border-top: none;
 }
 
 .pf-ri__topology-demo .pf-c-tab-content {

--- a/packages/demo-app-ts/src/Demos.ts
+++ b/packages/demo-app-ts/src/Demos.ts
@@ -11,6 +11,7 @@ import { ContextMenus } from './demos/ContextMenus';
 import { TopologyPackage } from './demos/TopologyPackage';
 import { ComplexGroup } from './demos/Groups';
 import { CollapsibleGroups } from './demos/CollapsibleGroups';
+import { StatusConnectors } from './demos/StatusConnectors';
 
 import './Demo.css';
 
@@ -38,6 +39,11 @@ export const Demos: DemoInterface[] = [
     id: 'topology-pipelines-demo',
     name: 'Topology Pipelines',
     componentType: TopologyPipelineDemo
+  },
+  {
+    id: 'status-connectors',
+    name: 'Status Connectors',
+    componentType: StatusConnectors,
   },
   {
     id: 'basic',

--- a/packages/demo-app-ts/src/components/FailedEdge.tsx
+++ b/packages/demo-app-ts/src/components/FailedEdge.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import { Edge, integralShapePath } from '@patternfly/react-topology';
+import styles from '@patternfly/react-topology/src/css/topology-components';
+
+interface FailedEdgeProps {
+  element: Edge;
+}
+
+const FailedEdge: React.FunctionComponent<FailedEdgeProps> = ({ element }) => {
+  const startPoint = element.getStartPoint();
+  const endPoint = element.getEndPoint();
+  const startIndent: number = element.getData()?.indent || 0;
+
+  const path = integralShapePath(startPoint, endPoint, startIndent, 10);
+  return (
+    <g data-test-id="task-handler" className={styles.topologyEdge} fillOpacity={0}>
+      <path
+        d={path}
+        transform="translate(0.5,0.5)"
+        shapeRendering="geometricPrecision"
+        stroke="red"
+      />
+    </g>
+  );
+};
+
+export default observer(FailedEdge);

--- a/packages/demo-app-ts/src/components/StatusConnectorNode.tsx
+++ b/packages/demo-app-ts/src/components/StatusConnectorNode.tsx
@@ -1,0 +1,151 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-topology/dist/esm/css/topology-components';
+import {
+  AnchorEnd,
+  Node,
+  Rectangle, useCombineRefs,
+  useSize,
+} from '@patternfly/react-topology';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import { useSourceStatusAnchor } from './useSourceStatusAnchor';
+import { useTargetStatusAnchor } from './useTargetStatusAnchor';
+
+const paddingX = 8;
+const paddingY = 8;
+const STATUS_RADIUS = 8;
+const STATUS_PADDING = 2;
+
+interface StatusConnectorNodeProps {
+  element: Node;
+}
+
+const StatusConnectorNode: React.FunctionComponent<StatusConnectorNodeProps> = ({ element }) => {
+  const label = element.getLabel();
+  const [textSize, textRef] = useSize([label]);
+  const [secondarySize, secondaryRef] = useSize([label]);
+  const successTargetRef = useTargetStatusAnchor(AnchorEnd.target, 'success-edge', -2);
+  const failedTargetRef = useTargetStatusAnchor(AnchorEnd.target, 'failed-edge', 2);
+  const targetRef = useCombineRefs(successTargetRef, failedTargetRef);
+  const successRef = useSourceStatusAnchor(AnchorEnd.source, 'success-edge');
+  const failedRef = useSourceStatusAnchor(AnchorEnd.source, 'failed-edge');
+
+  const textWidth = textSize?.width ?? 0;
+  const textHeight = textSize?.height ?? 0;
+  const secondaryWidth = secondarySize?.width ?? 0;
+  const secondaryHeight = secondarySize?.height ?? 0;
+
+  const {
+    height,
+    textStartX,
+    width,
+  } = React.useMemo(() => {
+    if (!textSize) {
+      return {
+        height: 0,
+        textStartX: 0,
+        width: 0,
+      };
+    }
+    const textStartX = paddingX;
+
+    const textSpace = Math.max(textWidth, secondaryWidth);
+
+    const width = paddingX + textSpace + paddingX * 2;
+    const secondaryStartY = paddingY + textHeight + paddingY / 2;
+
+    const height: number = secondaryStartY + secondaryHeight + paddingY;
+    return {
+      height,
+      textStartX,
+      width,
+    };
+  }, [textSize, textWidth, secondaryWidth, textHeight, secondaryHeight]);
+
+  const nameLabel = (
+    <text ref={textRef} dominantBaseline="middle">
+      {label}
+    </text>
+  );
+
+  const secondaryLabel = (
+    <text ref={secondaryRef} transform={`translate(0, ${textHeight + paddingY / 2})`} className={css(styles.modifiers.secondary)} dominantBaseline="middle">
+      {element.getData().secondaryLabel}
+    </text>
+  );
+
+  const iconRadius = STATUS_RADIUS - STATUS_PADDING;
+
+  const targetDecorator = (
+    <g className={styles.topologyNodeDecorator}>
+      <circle
+        cx={0}
+        cy={height / 2}
+        r={STATUS_RADIUS}
+        ref={targetRef}
+        className={css(styles.topologyNodeDecoratorBg)}
+      />
+    </g>
+  );
+  const successDecorator = (
+    <g className={styles.topologyNodeDecorator}>
+      <circle
+        cx={width}
+        cy={height / 3}
+        r={STATUS_RADIUS}
+        ref={successRef}
+        className={css(styles.topologyNodeDecoratorBg)}
+      />
+      <g
+        transform={`translate(${width -iconRadius}, ${height / 3 - iconRadius})`}
+        className={css(styles.topologyNodeDecoratorIcon)}
+        style={{ fontSize: `${iconRadius * 2}px` }}
+      >
+        <g className={css(styles.topologyNodeDecoratorStatus)}>
+          <CheckCircleIcon className="pf-m-success" />
+        </g>
+      </g>
+    </g>
+  );
+  const failedDecorator = (
+    <g className={styles.topologyNodeDecorator}>
+      <circle
+        cx={width}
+        cy={height - height / 3}
+        r={STATUS_RADIUS}
+        ref={failedRef}
+        className={css(styles.topologyNodeDecoratorBg)}
+      />
+      <g
+        transform={`translate(${width -iconRadius}, ${height - height / 3 - iconRadius})`}
+        className={css(styles.topologyNodeDecoratorIcon)}
+        style={{ fontSize: `${iconRadius * 2}px` }}
+      >
+        <g className={css(styles.topologyNodeDecoratorStatus)}>
+          <ExclamationCircleIcon className="pf-m-danger" />
+        </g>
+      </g>
+    </g>
+  );
+  return (
+    <g className={styles.topologyNode}>
+      <Rectangle
+        className={styles.topologyNodeBackground}
+        element={element}
+        width={width}
+        height={height}
+      />
+      <g transform={`translate(${textStartX}, ${paddingY + textHeight / 2 + 1})`} className={styles.topologyNodeLabel}>
+        {nameLabel}
+        {secondaryLabel}
+      </g>
+      {targetDecorator}
+      {successDecorator}
+      {failedDecorator}
+    </g>
+  );
+};
+
+export default observer(StatusConnectorNode);

--- a/packages/demo-app-ts/src/components/SuccessEdge.tsx
+++ b/packages/demo-app-ts/src/components/SuccessEdge.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import { Edge, integralShapePath, Layer, TOP_LAYER } from '@patternfly/react-topology';
+import styles from '@patternfly/react-topology/src/css/topology-components';
+
+interface SuccessEdgeProps {
+  element: Edge;
+}
+
+const SuccessEdge: React.FunctionComponent<SuccessEdgeProps> = ({ element }) => {
+  const startPoint = element.getStartPoint();
+  const endPoint = element.getEndPoint();
+  const startIndent: number = element.getData()?.indent || 0;
+
+  return (
+    <Layer id={TOP_LAYER}>
+      <g data-test-id="task-handler" className={styles.topologyEdge} fillOpacity={0}>
+        <path
+          d={integralShapePath(startPoint, endPoint, startIndent, 20)}
+          transform="translate(0.5,0.5)"
+          shapeRendering="geometricPrecision"
+          stroke="green"
+        />
+      </g>
+    </Layer>
+  );
+};
+
+export default observer(SuccessEdge);

--- a/packages/demo-app-ts/src/components/statusConnectorsComponentFactory.ts
+++ b/packages/demo-app-ts/src/components/statusConnectorsComponentFactory.ts
@@ -1,0 +1,37 @@
+import { ComponentType } from 'react';
+import {
+  GraphElement,
+  ComponentFactory,
+  ModelKind,
+  GraphComponent,
+  withPanZoom
+} from '@patternfly/react-topology';
+import Edge from './DefaultEdge';
+import StatusConnectorNode from './StatusConnectorNode';
+import SuccessEdge from './SuccessEdge';
+import FailedEdge from './FailedEdge';
+
+const statusConnectorsComponentFactory: ComponentFactory = (
+  kind: ModelKind,
+  type: string
+): ComponentType<{ element: GraphElement }> => {
+  switch (type) {
+    case 'failed-edge':
+      return FailedEdge;
+    case 'success-edge':
+      return SuccessEdge;
+    default:
+      switch (kind) {
+        case ModelKind.graph:
+          return withPanZoom()(GraphComponent);
+        case ModelKind.node:
+          return StatusConnectorNode;
+        case ModelKind.edge:
+          return Edge;
+        default:
+          return undefined;
+      }
+  }
+};
+
+export default statusConnectorsComponentFactory;

--- a/packages/demo-app-ts/src/components/useSourceStatusAnchor.tsx
+++ b/packages/demo-app-ts/src/components/useSourceStatusAnchor.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { action, observable } from 'mobx';
+import {
+  isNode,
+  AnchorEnd,
+  ElementContext,
+} from '@patternfly/react-topology';
+import AbstractAnchor from '@patternfly/react-topology/dist/esm/anchors/AbstractAnchor';
+import Point from '@patternfly/react-topology/dist/esm/geom/Point';
+
+export type SvgAnchorRef = (node: SVGElement | null) => void;
+
+class SourceStatusAnchor extends AbstractAnchor {
+  @observable.ref
+  private svgElement?: SVGElement;
+
+  setSVGElement(svgElement: SVGElement) {
+    this.svgElement = svgElement;
+  }
+
+  getReferencePoint(): Point {
+    const circle = this.svgElement as SVGCircleElement;
+    const center: Point = new Point(circle.cx.baseVal.value, circle.cy.baseVal.value);
+    this.owner.translateToParent(center);
+    const radius = circle.r.baseVal.value;
+
+    return new Point(center.x + radius, center.y);
+  }
+
+  getLocation(): Point {
+    return this.getReferencePoint();
+  }
+}
+
+export const useSourceStatusAnchor = (
+  end: AnchorEnd = AnchorEnd.both,
+  type: string = ''
+
+): ((node: SVGElement | null) => void) => {
+  const element = React.useContext(ElementContext);
+  if (!isNode(element)) {
+    throw new Error('useSvgAnchor must be used within the scope of a Node');
+  }
+
+  return React.useCallback<SvgAnchorRef>((node: SVGElement | null) => {
+    const actionFn = action((node: SVGElement | null) => {
+      if (node) {
+        const anchor = new SourceStatusAnchor(element);
+        anchor.setSVGElement(node);
+        element.setAnchor(anchor, end, type);
+      }
+    });
+    actionFn(node);
+  },[element, type, end]);
+};

--- a/packages/demo-app-ts/src/components/useTargetStatusAnchor.tsx
+++ b/packages/demo-app-ts/src/components/useTargetStatusAnchor.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { action, observable } from 'mobx';
+import {
+  AbstractAnchor,
+  AnchorEnd,
+  ElementContext,
+  isNode, Node,
+  Point,
+} from '@patternfly/react-topology';
+
+export type SvgAnchorRef = (node: SVGElement | null) => void;
+
+class TargetStatusAnchor<E extends Node = Node> extends AbstractAnchor {
+  @observable.ref
+  private svgElement?: SVGElement;
+
+  private centerOffset: number = 0;
+
+  constructor(owner: E, offset: number = 0) {
+    super(owner);
+    this.centerOffset = offset;
+  }
+
+  setSVGElement(svgElement: SVGElement) {
+    this.svgElement = svgElement;
+  }
+
+  getReferencePoint(): Point {
+    const circle = this.svgElement as SVGCircleElement;
+    const center: Point = new Point(circle.cx.baseVal.value, circle.cy.baseVal.value);
+    this.owner.translateToParent(center);
+    const radius = circle.r.baseVal.value;
+
+    return new Point(center.x - radius, center.y + this.centerOffset);
+  }
+
+  getLocation(): Point {
+    return this.getReferencePoint();
+  }
+}
+
+export const useTargetStatusAnchor = (
+  end: AnchorEnd = AnchorEnd.both,
+  type: string = '',
+  offset: number = 0
+
+): ((node: SVGElement | null) => void) => {
+  const element = React.useContext(ElementContext);
+  if (!isNode(element)) {
+    throw new Error('useSvgAnchor must be used within the scope of a Node');
+  }
+
+  return React.useCallback<SvgAnchorRef>((node: SVGElement | null) => {
+    const actionFn = action((node: SVGElement | null) => {
+      if (node) {
+        const anchor = new TargetStatusAnchor(element, offset);
+        anchor.setSVGElement(node);
+        element.setAnchor(anchor, end, type);
+      }
+    });
+    actionFn(node);
+  },[element, offset, end, type]);
+};

--- a/packages/demo-app-ts/src/demos/StatusConnectors.tsx
+++ b/packages/demo-app-ts/src/demos/StatusConnectors.tsx
@@ -1,0 +1,225 @@
+import * as React from 'react';
+import { action } from 'mobx';
+import {
+  createTopologyControlButtons,
+  DagreLayout,
+  defaultControlButtonsOptions,
+  EdgeModel,
+  Graph,
+  Layout,
+  LayoutFactory,
+  NODE_SEPARATION_HORIZONTAL,
+  NodeShape,
+  SELECTION_EVENT,
+  TopologyControlBar,
+  TopologyView,
+  useVisualizationController,
+  Visualization,
+  VisualizationProvider,
+  VisualizationSurface
+} from '@patternfly/react-topology';
+import statusConnectorsComponentFactory from '../components/statusConnectorsComponentFactory';
+import {
+  createNode,
+} from '../utils/styleUtils';
+import defaultComponentFactory from '../components/defaultComponentFactory';
+
+const DEFAULT_CHAR_WIDTH = 8;
+
+const getTextWidth = (text: string, font: string = '1rem RedHatText'): number => {
+  if (!text || text.length === 0) {
+    return 0;
+  }
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext?.('2d');
+  if (!context) {
+    return text.length * DEFAULT_CHAR_WIDTH;
+  }
+  context.font = font;
+  const { width } = context.measureText(text);
+
+  return width || text.length * DEFAULT_CHAR_WIDTH;
+};
+
+const defaultLayoutFactory: LayoutFactory = (type: string, graph: Graph): Layout | undefined => {
+  return new DagreLayout(graph, {
+    linkDistance: 10,
+    nodeDistance: 0,
+    groupDistance: 10,
+    allowDrag: false,
+    layoutOnDrag: false,
+    nodesep: NODE_SEPARATION_HORIZONTAL + 20,
+    ranksep: NODE_SEPARATION_HORIZONTAL,
+    edgesep: 100,
+    ranker: 'longest-path',
+    rankdir: 'LR',
+    marginx: 20,
+    marginy: 20,
+  });
+};
+
+export const StatusConnectorsDemo: React.FunctionComponent= () => {
+  const controller = useVisualizationController();
+  const [selectedIds, setSelectedIds] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    const nodes = [
+      createNode({
+        id: '1',
+        shape: NodeShape.rect,
+        label: 'Demo Job Template',
+        secondaryLabel: 'Job template',
+        setLocation: false,
+      }),
+      createNode({
+        id: '2',
+        shape: NodeShape.rect,
+        label: 'Demo Job Template @ 05:02:15:215PM',
+        secondaryLabel: 'Job template',
+        setLocation: false,
+      }),
+      createNode({
+        id: '3',
+        shape: NodeShape.rect,
+        label: 'Approval',
+        secondaryLabel: 'Approval',
+        setLocation: false,
+      }),
+      createNode({
+        id: '4',
+        shape: NodeShape.rect,
+        label: 'Demo Project',
+        secondaryLabel: 'Project',
+        setLocation: false,
+      }),
+      createNode({
+        id: '5',
+        shape: NodeShape.rect,
+        label: 'Cleanup Activity Stream',
+        secondaryLabel: 'System job',
+        setLocation: false,
+      }),
+    ];
+
+    const edges: EdgeModel[] = [
+      {
+        id: `edge-${1}-${2}`,
+        type: 'success-edge',
+        source: '1',
+        target: '2',
+      },
+      {
+        id: `edge-${1}-${3}`,
+        type: 'success-edge',
+        source: '1',
+        target: '3',
+      },
+      {
+        id: `edge-${1}-${4}`,
+        type: 'success-edge',
+        source: '1',
+        target: '4',
+      },
+      {
+        id: `edge-${1}-${5}`,
+        type: 'failed-edge',
+        source: '1',
+        target: '5',
+      },
+      {
+        id: `edge-${2}-${4}`,
+        type: 'failed-edge',
+        source: '2',
+        target: '4',
+      },
+      {
+        id: `edge-${3}-${4}`,
+        type: 'success-edge',
+        source: '3',
+        target: '4',
+      },
+      {
+        id: `edge-${3}-${5}`,
+        type: 'failed-edge',
+        source: '3',
+        target: '5',
+      },
+      {
+        id: `edge-${4}-${5}-success`,
+        type: 'success-edge',
+        source: '4',
+        target: '5',
+      },
+      {
+        id: `edge-${4}-${5}-failed`,
+        type: 'failed-edge',
+        source: '4',
+        target: '5',
+      },
+    ];
+
+    nodes.forEach((node) => {
+      node.width = getTextWidth(node.label);
+      node.height = 75;
+    });
+    nodes[1].width = Math.max(nodes[1].width, nodes[2].width);
+    nodes[2].width = nodes[1].width;
+
+    const graph = {
+      id: 'g1',
+      type: 'graph',
+      layout: 'Dagre'
+    };
+
+    const model = { graph, nodes, edges };
+
+    controller.addEventListener(SELECTION_EVENT, ids => {
+      setSelectedIds(ids);
+    });
+
+    controller.fromModel(model, false);
+  }, [controller]);
+
+  return (
+    <TopologyView
+      controlBar={
+        <TopologyControlBar
+          controlButtons={createTopologyControlButtons({
+            ...defaultControlButtonsOptions,
+            zoomInCallback: action(() => {
+              controller.getGraph().scaleBy(4 / 3);
+            }),
+            zoomOutCallback: action(() => {
+              controller.getGraph().scaleBy(0.75);
+            }),
+            fitToScreenCallback: action(() => {
+              controller.getGraph().fit(80);
+            }),
+            resetViewCallback: action(() => {
+              controller.getGraph().reset();
+              controller.getGraph().layout();
+            }),
+            legend: false
+          })}
+        />
+      }
+    >
+      <VisualizationSurface state={{ selectedIds }} />
+    </TopologyView>
+  );
+};
+
+
+
+export const StatusConnectors = React.memo(() => {
+  const controller = new Visualization();
+  controller.registerLayoutFactory(defaultLayoutFactory);
+  controller.registerComponentFactory(defaultComponentFactory);
+  controller.registerComponentFactory(statusConnectorsComponentFactory);
+
+  return (
+    <VisualizationProvider controller={controller}>
+      <StatusConnectorsDemo />
+    </VisualizationProvider>
+  );
+});

--- a/packages/demo-app-ts/tsconfig.json
+++ b/packages/demo-app-ts/tsconfig.json
@@ -20,7 +20,8 @@
     "strictPropertyInitialization": false,
     "strictNullChecks": false,
     "strictFunctionTypes": false,
-    "sourceMap": true
+    "sourceMap": true,
+    "experimentalDecorators": true
   },
   "include": [
     "./src/*",


### PR DESCRIPTION
## What
Closes #13

## Description
Fixes curved line drawing by `integralShapePath` when nodes are offset by less than the curve height.
Adds a complex anchor demo to demonstrate creating nodes with anchors based on offsets and edge types.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review

### Before:
![image](https://user-images.githubusercontent.com/11633780/235177243-f6f104ec-9755-4640-8592-35316334f848.png)

### After:
![image](https://user-images.githubusercontent.com/11633780/235177330-dd826414-ee78-4f75-b148-16ffe551353b.png)




