### PR TITLE
fix: Style updates per dark theme audit

### DIFF
--- a/packages/demo-app-ts/src/App.tsx
+++ b/packages/demo-app-ts/src/App.tsx
@@ -52,9 +52,9 @@ class App extends React.Component<{}, AppState> {
     const htmlElement = document.getElementsByTagName('html')[0];
     if (htmlElement) {
       if (isDarkTheme) {
-        htmlElement.classList.add('pf-theme-dark');
+        htmlElement.classList.add('pf-v5-theme-dark');
       } else {
-        htmlElement.classList.remove('pf-theme-dark');
+        htmlElement.classList.remove('pf-v5-theme-dark');
       }
     }
   };

--- a/packages/demo-app-ts/src/demos/Styles.tsx
+++ b/packages/demo-app-ts/src/demos/Styles.tsx
@@ -294,11 +294,11 @@ export const NodeIconLabelStyles = withTopologySetup(() => {
 export const NodeSecondaryLabelStyles = withTopologySetup(() => {
   useComponentFactory(defaultComponentFactory);
   useComponentFactory(stylesComponentFactory);
-  const nodes = Object.values(NodeShape).reduce((nodes: NodeModel[], shape: string | NodeShape, index) => {
+  const nodes = Object.values(NodeStatus).reduce((nodes: NodeModel[], status: NodeStatus, index) => {
     nodes.push(
       createNode({
-        id: `${shape}-secondary`,
-        shape: shape as NodeShape,
+        id: `${status}-secondary`,
+        status,
         label: 'Primary Label',
         secondaryLabel: 'Secondary Label',
         labelPosition: LabelPosition.bottom,
@@ -310,28 +310,40 @@ export const NodeSecondaryLabelStyles = withTopologySetup(() => {
     );
     nodes.push(
       createNode({
-        id: `${shape}-secondary-long`,
-        shape: shape as NodeShape,
+        id: `${status}-secondary-selected`,
+        status,
         label: 'Primary Label',
-        secondaryLabel: 'Very Long Secondary Label',
+        selected: true,
+        secondaryLabel: 'Selected Label',
         labelPosition: LabelPosition.bottom,
         row: 2,
         column: index + 1,
         x: index * RIGHT_LABEL_COLUMN_WIDTH,
-        y: 165,
         truncateLength: 13
       })
     );
     nodes.push(
       createNode({
-        id: `${shape}-secondary-long-badged`,
-        label: 'Label Bottom',
+        id: `${status}-secondary-long`,
+        status,
+        label: 'Primary Label',
         secondaryLabel: 'Very Long Secondary Label',
-        shape: shape as NodeShape,
+        labelPosition: LabelPosition.bottom,
         row: 3,
         column: index + 1,
+        x: index * RIGHT_LABEL_COLUMN_WIDTH,
+        truncateLength: 13
+      })
+    );
+    nodes.push(
+      createNode({
+        id: `${status}-secondary-long-badged`,
+        label: 'Label Bottom',
+        secondaryLabel: 'Very Long Secondary Label',
+        status,
+        row: 4,
+        column: index + 1,
         x: index * (RIGHT_LABEL_COLUMN_WIDTH + 45),
-        y: 330,
         labelIconClass: logos.get('icon-java'),
         truncateLength: 13,
         badge: 'CS',

--- a/packages/demo-app-ts/src/utils/styleUtils.ts
+++ b/packages/demo-app-ts/src/utils/styleUtils.ts
@@ -66,8 +66,8 @@ export const EDGE_TERMINAL_TYPES = [
   EdgeTerminalType.circle,
   EdgeTerminalType.square,
   EdgeTerminalType.cross,
+  EdgeTerminalType.directional,
   EdgeTerminalType.none,
-  EdgeTerminalType.directional
 ];
 export const EDGE_TERMINAL_TYPES_COUNT = EDGE_TERMINAL_TYPES.length;
 

--- a/packages/module/src/components/edges/DefaultEdge.tsx
+++ b/packages/module/src/components/edges/DefaultEdge.tsx
@@ -7,7 +7,7 @@ import { getClosestVisibleParent, useHover } from '../../utils';
 import { Layer } from '../layers';
 import { css } from '@patternfly/react-styles';
 import styles from '../../css/topology-components';
-import { getEdgeAnimationDuration, getEdgeStyleClassModifier } from '../../utils/style-utils';
+import { getEdgeAnimationDuration, getEdgeStyleClassModifier, StatusModifier } from '../../utils/style-utils';
 import DefaultConnectorTerminal from './terminals/DefaultConnectorTerminal';
 import { TOP_LAYER } from '../../const';
 import DefaultConnectorTag from './DefaultConnectorTag';
@@ -117,7 +117,8 @@ const DefaultEdgeInner: React.FunctionComponent<DefaultEdgeInnerProps> = observe
     className,
     dragging && 'pf-m-dragging',
     hover && !dragging && 'pf-m-hover',
-    selected && !dragging && 'pf-m-selected'
+    selected && !dragging && 'pf-m-selected',
+    StatusModifier[endTerminalStatus]
   );
 
   const edgeAnimationDuration = animationDuration ?? getEdgeAnimationDuration(element.getEdgeAnimationSpeed());

--- a/packages/module/src/css/topology-components.css
+++ b/packages/module/src/css/topology-components.css
@@ -53,10 +53,10 @@
   --pf-topology__node--m-selected--m-success--node__label__text--Fill: var(--pf-v5-global--Color--light-100);
 
   --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-v5-global--Color--light-100);
-  --pf-topology__node--m-selected--m-info--node__label__text-m-secondary--Fill: var(--pf-v5-global--palette--black-1000);
-  --pf-topology__node--m-selected--m-warning--node__label__text-m-secondary--Fill: var(--pf-v5-global--palette--black-1000);
-  --pf-topology__node--m-selected--m-success--node__label__text-m-secondary--Fill: var(--pf-v5-global--Color--light-100);
-  --pf-topology__node--m-selected--m-danger--node__label__text-m-secondary--Fill: var(--pf-v5-global--Color--light-100);
+  --pf-topology__node--m-selected--m-info--node__label__text--m-secondary--Fill: var(--pf-v5-global--palette--black-1000);
+  --pf-topology__node--m-selected--m-warning--node__label__text--m-secondary--Fill: var(--pf-v5-global--palette--black-1000);
+  --pf-topology__node--m-selected--m-success--node__label__text--m-secondary--Fill: var(--pf-v5-global--Color--light-100);
+  --pf-topology__node--m-selected--m-danger--node__label__text--m-secondary--Fill: var(--pf-v5-global--Color--light-100);
 
   --pf-topology__node__label__background--Fill: var(--pf-v5-global--BackgroundColor--100);
   --pf-topology__node__label__background--Stroke: var(--pf-v5-global--BorderColor--100);
@@ -196,9 +196,9 @@
   --pf-topology__node__label__text--Fill: var(--pf-v5-global--Color--100);
 
   /* dark selected nodes */
-  --pf-topology__node--m-selected--node__background--Stroke: var(--pf-v5-global--palette--blue-300);
-  --pf-topology__node--m-selected--node__label__background--Stroke: var(--pf-v5-global--palette--blue-400);
-  --pf-topology__node--m-selected--node__label__background--Fill: var(--pf-v5-global--palette--blue-400);
+  --pf-topology__node--m-selected--node__background--Stroke: var(--pf-v5-global--primary-color--300);
+  --pf-topology__node--m-selected--node__label__background--Stroke: var(--pf-v5-global--primary-color--300);
+  --pf-topology__node--m-selected--node__label__background--Fill: var(--pf-v5-global--primary-color--300);
 
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-v5-global--Color--100);
   --pf-topology__node--m-selected--m-info--node__label__text--Fill: var(--pf-v5-global--palette--black-900);
@@ -206,12 +206,11 @@
   --pf-topology__node--m-selected--m-warning--node__label__text--Fill: var(--pf-v5-global--palette--black-900);
   --pf-topology__node--m-selected--m-success--node__label__text--Fill: var(--pf-v5-global--palette--black-900);
 
-  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-v5-global--palette--black-100);
-  --pf-topology__node--m-selected--m-info--node__label__text--m-secondary--Fill: var(--pf-v5-global--palette--black-900);
+  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--node__label__text--Fill);
+  --pf-topology__node--m-selected--m-info--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-info--node__label__text--Fill);
+  --pf-topology__node--m-selected--m-warning--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-warning--node__label__text--Fill);
+  --pf-topology__node--m-selected--m-success--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-success--node__label__text--Fill);
   --pf-topology__node--m-selected--m-danger--node__label__text--m-secondary--Fill: var(--pf-v5-global--palette--black-900);
-  --pf-topology__node--m-selected--m-warning--node__label__text--m-secondary--Fill: var(--pf-v5-global--palette--black-900);
-  --pf-topology__node--m-selected--m-success--node__label__text-m-secondary--Fill: var(--pf-v5-global--palette--black-900);
-  --pf-topology__node--m-selected--m-danger--node__label__text-m-secondary--Fill: var(--pf-v5-global--palette--black-900);
 
   --pf-topology__node__label__icon--Color: var(--pf-v5-global--palette--black-600);
 
@@ -450,25 +449,25 @@
 .pf-topology__node.pf-m-selected.pf-m-info {
   --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--m-info--node__label__background--Fill);
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-topology__node--m-selected--m-info--node__label__text--Fill);
-  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-info--node__label__text-m-secondary--Fill);
+  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-info--node__label__text--m-secondary--Fill);
 }
 
 .pf-topology__node.pf-m-selected.pf-m-danger  {
   --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--m-danger--node__label__background--Fill);
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-topology__node--m-selected--m-danger--node__label__text--Fill);
-  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-danger--node__label__text-m-secondary--Fill);
+  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-danger--node__label__text--m-secondary--Fill);
 }
 
 .pf-topology__node.pf-m-selected.pf-m-warning {
   --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--m-warning--node__label__background--Fill);
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-topology__node--m-selected--m-warning--node__label__text--Fill);
-  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-warning--node__label__text-m-secondary--Fill);
+  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-warning--node__label__text--m-secondary--Fill);
 }
 
 .pf-topology__node.pf-m-selected.pf-m-success {
   --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--m-success--node__label__background--Fill);
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-topology__node--m-selected--m-success--node__label__text--Fill);
-  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-success--node__label__text-m-secondary--Fill);
+  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-success--node__label__text--m-secondary--Fill);
 }
 
 /* Node label badge */

--- a/packages/module/src/css/topology-components.css
+++ b/packages/module/src/css/topology-components.css
@@ -47,11 +47,16 @@
   --pf-topology__node__label__text--m-secondary--Fill: var(--pf-v5-global--Color--200);
 
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-v5-global--Color--light-100);
-  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-v5-global--Color--light-100);
-  --pf-topology__node--m-selected--m-info--node__label__text--Fill: var(--pf-v5-global--Color--light-100);
+  --pf-topology__node--m-selected--m-info--node__label__text--Fill: var(--pf-v5-global--palette--black-1000);
   --pf-topology__node--m-selected--m-danger--node__label__text--Fill: var(--pf-v5-global--Color--light-100);
-  --pf-topology__node--m-selected--m-warning--node__label__text--Fill: var(--pf-v5-global--Color--light-100);
+  --pf-topology__node--m-selected--m-warning--node__label__text--Fill: var(--pf-v5-global--palette--black-1000);
   --pf-topology__node--m-selected--m-success--node__label__text--Fill: var(--pf-v5-global--Color--light-100);
+
+  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-v5-global--Color--light-100);
+  --pf-topology__node--m-selected--m-info--node__label__text-m-secondary--Fill: var(--pf-v5-global--palette--black-1000);
+  --pf-topology__node--m-selected--m-warning--node__label__text-m-secondary--Fill: var(--pf-v5-global--palette--black-1000);
+  --pf-topology__node--m-selected--m-success--node__label__text-m-secondary--Fill: var(--pf-v5-global--Color--light-100);
+  --pf-topology__node--m-selected--m-danger--node__label__text-m-secondary--Fill: var(--pf-v5-global--Color--light-100);
 
   --pf-topology__node__label__background--Fill: var(--pf-v5-global--BackgroundColor--100);
   --pf-topology__node__label__background--Stroke: var(--pf-v5-global--BorderColor--100);
@@ -104,6 +109,7 @@
 
   --pf-topology__group--m-selected--topology__group__background--Stroke: var(--pf-v5-global--active-color--100);
   --pf-topology__group--m-hover--topology__group__background--Stroke: var(--pf-v5-global--BackgroundColor--dark-400);
+  --pf-topology__group--m-selected--m-hover--topology__group__background--Stroke: var(--pf-v5-global--palette--blue-600);
   --pf-topology__group--m-drop-target--topology__group__background--Fill: var(--pf-v5-global--palette--blue-50);
   --pf-topology__group--m-drop-target--topology__group__background--Stroke: var(--pf-v5-global--active-color--100);
   --pf-topology__group__collapsed-badge__node__label__badge__rect--Fill: var(--pf-v5-global--palette--white);
@@ -158,7 +164,7 @@
 }
 
 /* DARK THEME OVERRIDES */
-:root:where(.pf-theme-dark) {
+:root:where(.pf-v5-theme-dark) {
   --pf-topology-visualization-surface--BackgroundColor: var(--pf-v5-global--BackgroundColor--200);
 
   --pf-topology__node--Color: var(--pf-v5-global--Color--100);
@@ -193,13 +199,19 @@
   --pf-topology__node--m-selected--node__background--Stroke: var(--pf-v5-global--palette--blue-300);
   --pf-topology__node--m-selected--node__label__background--Stroke: var(--pf-v5-global--palette--blue-400);
   --pf-topology__node--m-selected--node__label__background--Fill: var(--pf-v5-global--palette--blue-400);
-  --pf-topology__node--m-selected--separator--Stroke: var(--pf-v5-global--palette--blue-300);
 
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-v5-global--Color--100);
   --pf-topology__node--m-selected--m-info--node__label__text--Fill: var(--pf-v5-global--palette--black-900);
   --pf-topology__node--m-selected--m-danger--node__label__text--Fill: var(--pf-v5-global--palette--black-900);
   --pf-topology__node--m-selected--m-warning--node__label__text--Fill: var(--pf-v5-global--palette--black-900);
   --pf-topology__node--m-selected--m-success--node__label__text--Fill: var(--pf-v5-global--palette--black-900);
+
+  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-v5-global--palette--black-100);
+  --pf-topology__node--m-selected--m-info--node__label__text--m-secondary--Fill: var(--pf-v5-global--palette--black-900);
+  --pf-topology__node--m-selected--m-danger--node__label__text--m-secondary--Fill: var(--pf-v5-global--palette--black-900);
+  --pf-topology__node--m-selected--m-warning--node__label__text--m-secondary--Fill: var(--pf-v5-global--palette--black-900);
+  --pf-topology__node--m-selected--m-success--node__label__text-m-secondary--Fill: var(--pf-v5-global--palette--black-900);
+  --pf-topology__node--m-selected--m-danger--node__label__text-m-secondary--Fill: var(--pf-v5-global--palette--black-900);
 
   --pf-topology__node__label__icon--Color: var(--pf-v5-global--palette--black-600);
 
@@ -212,7 +224,8 @@
   --pf-topology__group--m-alt-group--topology__group__background--Stroke: var(--pf-v5-global--BorderColor--100);
   --pf-topology__group--m-selected--topology__group__background--Fill: var(--pf-v5-global--primary-color--300);
   --pf-topology__group--m-selected--topology__group__background--Stroke: var(--pf-v5-global--active-color--300);
-  --pf-topology__group--m-hover--topology__group__background--Stroke: var(--pf-v5-global--palette--black-100);
+  --pf-topology__group--m-hover--topology__group__background--Stroke: var(--pf-v5-global--primary-color--light-100);
+  --pf-topology__group--m-selected--m-hover--topology__group__background--Stroke: var(--pf-v5-global--palette--blue-100);
   --pf-topology__group--m-drop-target--topology__group__background--Stroke: var(--pf-v5-global--palette--blue-300);
 
   --pf-topology__group__label__node__label__background--StrokeWidth: 2px;
@@ -233,12 +246,6 @@
   --pf-topology__edge__tag__text--Fill: var(--pf-v5-global--palette--black-900);
   --pf-topology__edge__tag__text--Stroke: var(--pf-v5-global--palette--black-900);
 
-}
-
-:root:where(.pf-theme-dark) .pfext-catalog-item-icon__img--large {
-  /* Not perfect, but gives a better result for colors than just inverting
-  by inverts to switch b/w, then rotates to get colors approximately back */
-  filter: brightness(1.5) invert(1) hue-rotate(180deg) saturate(4);
 }
 
 .pf-topology-visualization-surface {
@@ -394,6 +401,11 @@
 }
 
 /* Node label */
+.pf-topology__node.pf-m-selected {
+  --pf-topology__node__label__text--Fill: var(--pf-topology__node--m-selected--node__label__text--Fill);
+  --pf-topology__node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--node__label__text--m-secondary--Fill);
+}
+
 .pf-topology__node__label > text {
   fill: var(--pf-topology__node__label__text--Fill);
   font-size: var(--pf-v5-global--FontSize--sm);
@@ -403,11 +415,6 @@
 .pf-topology__node__label > text.pf-m-secondary {
   fill: var(--pf-topology__node__label__text--m-secondary--Fill);
   font-size: var(--pf-v5-global--FontSize--xs);
-}
-
-.pf-topology__node.pf-m-selected .pf-topology__node__label > text {
-  --pf-topology__node__label__text--Fill: var(--pf-topology__node--m-selected--node__label__text--Fill);
-  --pf-topology__node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--node__label__text--m-secondary--Fill);
 }
 
 .pf-topology__node__label__background {
@@ -420,7 +427,7 @@
   stroke-width: 2px;
   --pf-topology__node__label__background--Stroke: var(--pf-topology__node--m-selected--node__label__background--Stroke);
   --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--node__label__background--Fill);
-  --pf-topology__node__separator--Stroke: var(--pf-topology__node--m-selected--separator--Stroke);
+  --pf-topology__node__separator--Stroke: var(--pf-topology__node--m-selected--node__label__text--m-secondary--Fill);
   --pf-topology__node__action-icon__icon--Color: var(--pf-topology__node--m-selected--action-icon__icon--Color);
 }
 
@@ -443,21 +450,25 @@
 .pf-topology__node.pf-m-selected.pf-m-info {
   --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--m-info--node__label__background--Fill);
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-topology__node--m-selected--m-info--node__label__text--Fill);
+  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-info--node__label__text-m-secondary--Fill);
 }
 
 .pf-topology__node.pf-m-selected.pf-m-danger  {
   --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--m-danger--node__label__background--Fill);
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-topology__node--m-selected--m-danger--node__label__text--Fill);
+  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-danger--node__label__text-m-secondary--Fill);
 }
 
 .pf-topology__node.pf-m-selected.pf-m-warning {
   --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--m-warning--node__label__background--Fill);
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-topology__node--m-selected--m-warning--node__label__text--Fill);
+  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-warning--node__label__text-m-secondary--Fill);
 }
 
 .pf-topology__node.pf-m-selected.pf-m-success {
   --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--m-success--node__label__background--Fill);
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-topology__node--m-selected--m-success--node__label__text--Fill);
+  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--m-success--node__label__text-m-secondary--Fill);
 }
 
 /* Node label badge */
@@ -562,7 +573,7 @@
 
 .pf-topology__group.pf-m-hover.pf-m-selected .pf-topology__group__background {
   --pf-topology__group__background--Fill: var(--pf-topology__group--m-selected--topology__group__background--Fill);
-  --pf-topology__group__background--Stroke: var(--pf-topology__group--m-hover--topology__group__background--Stroke);
+  --pf-topology__group__background--Stroke: var(--pf-topology__group--m-selected--m-hover--topology__group__background--Stroke);
   --pf-topology__group__label__node__label__background--Stroke: var(--pf-topology__group--m-hover--label__node__label__background--Stroke);
 }
 
@@ -631,17 +642,21 @@
 
 .pf-topology__edge.pf-m-info {
   --edge--stroke: var(--pf-topology__edge--m-info--EdgeStroke);
+  --edge--fill: var(--pf-v5-global--primary-color--light-100);
 }
 
 .pf-topology__edge.pf-m-success {
   --edge--stroke: var(--pf-topology__edge--m-success--EdgeStroke);
+  --edge--fill: var(--pf-v5-global--success-color--100);
 }
 .pf-topology__edge.pf-m-warning {
   --edge--stroke: var(--pf-topology__edge--m-warning--EdgeStroke);
+  --edge--fill: var(--pf-v5-global--warning-color--100);
 }
 
 .pf-topology__edge.pf-m-danger {
   --edge--stroke: var(--pf-topology__edge--m-danger--EdgeStroke);
+  --edge--file: var(--pf-v5-global--danger-color--100);
 }
 
 .pf-topology__edge__background {

--- a/packages/module/src/css/topology-pipelines.css
+++ b/packages/module/src/css/topology-pipelines.css
@@ -120,7 +120,7 @@
 
 
 /* DARK THEME OVERRIDES */
-:root:where(.pf-theme-dark) {
+:root:where(.pf-v5-theme-dark) {
 
   /* dark pill */
   --pf-topology-pipelines__pill--Color: var(--pf-v5-global--Color--100);
@@ -144,6 +144,9 @@
   --pf-topology-pipelines__pill__label__icon--Color: var(--pf-v5-global--palette--black-600);
 
   --pf-topology-pipelines__pill__action-icon__icon--Color: var(--pf-v5-global--Color--100);
+
+  --pf-topology-pipelines__pill-badge--fill: var(--pf-v5-global--palette--black-500);
+  --pf-topology-pipelines__pill-badge--text--fill: var(--pf-v5-global--Color--100);
 }
 
 .pf-topology-pipelines__pill {


### PR DESCRIPTION
## What
Fixes #63

## Description
Update color styles per [dark theme audit](https://github.com/patternfly/react-topology/issues/49).

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review

### Light Theme Labels:
![image](https://github.com/patternfly/react-topology/assets/11633780/a327c2c1-4b47-4a22-afcf-a1ad5fab0a39)

### Dark Theme Labels:
![image](https://github.com/patternfly/react-topology/assets/11633780/ffaf8455-beb8-4886-be6c-d4d174b48d21)

### Light Theme Selected Group Hover:
![image](https://github.com/patternfly/react-topology/assets/11633780/507d43d9-0088-49bd-8df5-30c71d825b76)

### Dark Theme Selected Group Hover:
![image](https://github.com/patternfly/react-topology/assets/11633780/a9699caa-9e5a-444d-8f98-f9aedfab2bcd)


/cc @mceledonia @andrew-ronaldson 
