### PR TITLE
add StatusIconComponent prop to TaskNode for overridable StatusIcon

### DIFF
--- a/packages/module/src/pipelines/components/nodes/TaskNode.tsx
+++ b/packages/module/src/pipelines/components/nodes/TaskNode.tsx
@@ -11,7 +11,7 @@ import { OnSelect, useAnchor } from '../../../behavior';
 import { truncateMiddle } from '../../../utils/truncate-middle';
 import { createSvgIdUrl, getNodeScaleTranslation, useCombineRefs, useHover, useSize } from '../../../utils';
 import { getRunStatusModifier, nonShadowModifiers } from '../../utils';
-import StatusIcon from '../../utils/StatusIcon';
+import StatusIcon, { StatusIconProps } from '../../utils/StatusIcon';
 import { TaskNodeSourceAnchor, TaskNodeTargetAnchor } from '../anchors';
 import LabelActionIcon from '../../../components/nodes/labels/LabelActionIcon';
 import LabelContextMenu from '../../../components/nodes/labels/LabelContextMenu';
@@ -108,6 +108,8 @@ export interface TaskNodeProps {
   onContextMenu?: (e: React.MouseEvent) => void;
   /** Flag indicating that the context menu for the node is currently open  */
   contextMenuOpen?: boolean;
+  /** Override the default StatusIcon component with custom conditions and icons */
+  StatusIconComponent?: React.FC<StatusIconProps>;
 }
 
 const TaskNode: React.FC<TaskNodeProps & { innerRef: React.Ref<SVGGElement> }> = ({
@@ -149,6 +151,7 @@ const TaskNode: React.FC<TaskNodeProps & { innerRef: React.Ref<SVGGElement> }> =
   actionIcon,
   actionIconClassName,
   onActionIconClick,
+  StatusIconComponent = StatusIcon,
   children
 }: TaskNodeProps & { innerRef?: React.Ref<SVGGElement> }) => {
   const [hovered, innerHoverRef] = useHover();
@@ -370,7 +373,7 @@ const TaskNode: React.FC<TaskNodeProps & { innerRef: React.Ref<SVGGElement> }> =
                   (status === RunStatus.Running || status === RunStatus.InProgress) && styles.modifiers.spin
                 )}
               >
-                <StatusIcon status={status} />
+                <StatusIconComponent status={status} />
               </g>
             </g>
           ) : null}
@@ -413,7 +416,7 @@ const TaskNode: React.FC<TaskNodeProps & { innerRef: React.Ref<SVGGElement> }> =
                 (status === RunStatus.Running || status === RunStatus.InProgress) && styles.modifiers.spin
               )}
             >
-              <StatusIcon status={status} />
+              <StatusIconComponent status={status} />
             </g>
           </g>
         )}

--- a/packages/module/src/pipelines/utils/StatusIcon.tsx
+++ b/packages/module/src/pipelines/utils/StatusIcon.tsx
@@ -9,7 +9,7 @@ import HourglassHalfIcon from '@patternfly/react-icons/dist/esm/icons/hourglass-
 import SyncAltIcon from '@patternfly/react-icons/dist/esm/icons/sync-alt-icon';
 import { RunStatus } from '../types';
 
-interface StatusIconProps {
+export interface StatusIconProps {
   className?: string;
   status: RunStatus;
   height?: number;


### PR DESCRIPTION
## What
Closes #65 

## Description

It is currently not easy to supply your own icons for the topology pipeline.  The current `StatusIcon` component is not exposed from `TaskNode` and you can only display the icons based on the `RunStatus` enum.

This PR adds a `StatusIconComponent` prop to `TaskNode` that defaults to `StatusIcon`.

## Type of change

- [X] Feature

## Screen shots / Gifs for design review


