### PR TITLE
doc: Fix link to model in getting started doc

### DIFF
--- a/packages/module/patternfly-docs/content/examples/TopologyGettingStarted.md
+++ b/packages/module/patternfly-docs/content/examples/TopologyGettingStarted.md
@@ -7,7 +7,7 @@ propComponents: ['VisualizationProvider', 'VisualizationSurface']
 ---
 Note: Topology lives in its own package at [`@patternfly/react-topology`](https://www.npmjs.com/package/@patternfly/react-topology)
 
-To use React Topology out-of-the-box, you will first need to transform your back-end data into a [Model](https://github.com/patternfly/patternfly-react/blob/main/packages/react-topology/src/types.ts#L16-L20). These model objects contain the information needed to display the nodes and edges. Each node and edge has a set of properties used by PF Topology as well as a data field which can be used to customize the nodes and edges by the application.
+To use React Topology out-of-the-box, you will first need to transform your back-end data into a [Model](https://github.com/patternfly/react-topology/blob/main/packages/module/src/types.ts#L16-L20). These model objects contain the information needed to display the nodes and edges. Each node and edge has a set of properties used by PF Topology as well as a data field which can be used to customize the nodes and edges by the application.
 
 import {
   ColaLayout,


### PR DESCRIPTION
## What
Closes #78 

## Description
Update the url to the code for the `Model` type in the getting started doc page.

## Type of change
- [x] Documentation content changes


