### PR TITLE
fix: revert linting update to verify prerelease version

### DIFF
--- a/packages/module/patternfly-docs/content/examples/TopologySelectableDemo.tsx
+++ b/packages/module/patternfly-docs/content/examples/TopologySelectableDemo.tsx
@@ -52,7 +52,7 @@ const BadgeColors = [
 const CustomNode: React.FC<CustomNodeProps & WithSelectionProps> = ({ element, onSelect, selected }) => {
   const data = element.getData();
   const Icon = data.isAlternate ? Icon2 : Icon1;
-  const badgeColors = BadgeColors.find((badgeColor) => badgeColor.name === data.badge);
+  const badgeColors = BadgeColors.find(badgeColor => badgeColor.name === data.badge);
 
   return (
     <DefaultNode


### PR DESCRIPTION
## What
Towards #88 - verify npm publishes correct v4 prerelease version

