### PR TITLE
added property to set whether the outline is hull or rect

### DIFF
--- a/packages/demo-app-ts/src/components/StyleGroup.tsx
+++ b/packages/demo-app-ts/src/components/StyleGroup.tsx
@@ -84,7 +84,6 @@ const StyleGroup: React.FunctionComponent<StyleGroupProps> = ({
       collapsedWidth={collapsedWidth}
       collapsedHeight={collapsedHeight}
       showLabel={detailsLevel === ScaleDetailsLevel.high}
-      hulledOutline={true}
       {...rest}
       {...passedData}
     >

--- a/packages/demo-app-ts/src/components/StyleGroup.tsx
+++ b/packages/demo-app-ts/src/components/StyleGroup.tsx
@@ -84,7 +84,7 @@ const StyleGroup: React.FunctionComponent<StyleGroupProps> = ({
       collapsedWidth={collapsedWidth}
       collapsedHeight={collapsedHeight}
       showLabel={detailsLevel === ScaleDetailsLevel.high}
-      hulledOutline={false}
+      hulledOutline={true}
       {...rest}
       {...passedData}
     >

--- a/packages/demo-app-ts/src/components/StyleGroup.tsx
+++ b/packages/demo-app-ts/src/components/StyleGroup.tsx
@@ -84,7 +84,7 @@ const StyleGroup: React.FunctionComponent<StyleGroupProps> = ({
       collapsedWidth={collapsedWidth}
       collapsedHeight={collapsedHeight}
       showLabel={detailsLevel === ScaleDetailsLevel.high}
-      hulledOutline={true}
+      hulledOutline={false}
       {...rest}
       {...passedData}
     >

--- a/packages/demo-app-ts/src/components/StyleGroup.tsx
+++ b/packages/demo-app-ts/src/components/StyleGroup.tsx
@@ -84,6 +84,7 @@ const StyleGroup: React.FunctionComponent<StyleGroupProps> = ({
       collapsedWidth={collapsedWidth}
       collapsedHeight={collapsedHeight}
       showLabel={detailsLevel === ScaleDetailsLevel.high}
+      hulledOutline={true}
       {...rest}
       {...passedData}
     >

--- a/packages/demo-app-ts/src/data/generator.ts
+++ b/packages/demo-app-ts/src/data/generator.ts
@@ -33,6 +33,7 @@ export interface GeneratorNodeOptions {
   nodeIcons?: boolean;
   smallNodes?: boolean;
   contextMenus?: boolean;
+  hulledOutline?: boolean;
 }
 
 export interface GeneratorEdgeOptions {
@@ -53,7 +54,8 @@ export const DefaultNodeOptions: GeneratorNodeOptions = {
   nodeBadges: false,
   nodeIcons: false,
   smallNodes: false,
-  contextMenus: false
+  contextMenus: false,
+  hulledOutline: true
 };
 
 export const DefaultEdgeOptions: GeneratorEdgeOptions = {
@@ -76,6 +78,7 @@ export const getNodeOptions = (
   showStatusDecorator?: boolean;
   showDecorators?: boolean;
   showContextMenu?: boolean;
+  hulledOutline?: boolean;
   labelIconClass?: string;
   labelIcon?: React.ComponentClass<SVGIconProps>;
 } => {
@@ -91,6 +94,7 @@ export const getNodeOptions = (
     showStatusDecorator: nodeCreationOptions.statusDecorators,
     showDecorators: nodeCreationOptions.showDecorators,
     showContextMenu: nodeCreationOptions.contextMenus,
+    hulledOutline: nodeCreationOptions.hulledOutline,
     labelIconClass,
     labelIcon
   };
@@ -128,6 +132,23 @@ export const generateEdge = (
     tag: options.edgeTags ? '250kbs' : undefined,
     tagStatus: options.edgeStatuses[index % options.edgeStatuses.length]
   });
+
+export const updateGroup = (group: NodeModel, nodeCreationOptions: GeneratorNodeOptions): NodeModel => {
+  return {
+    ...group,
+    data: {
+      badge: nodeCreationOptions.nodeBadges ? 'GN' : undefined,
+      badgeColor: '#F2F0FC',
+      badgeTextColor: '#5752d1',
+      badgeBorderColor: '#CBC1FF',
+      collapsedWidth: 75,
+      collapsedHeight: 75,
+      showContextMenu: nodeCreationOptions.contextMenus,
+      collapsible: true,
+      hulledOutline: nodeCreationOptions.hulledOutline
+    }
+  };
+};
 
 export const generateDataModel = (
   numNodes: number,
@@ -167,7 +188,8 @@ export const generateDataModel = (
         collapsedWidth: 75,
         collapsedHeight: 75,
         showContextMenu: nodeCreationOptions.contextMenus,
-        collapsible: true
+        collapsible: true,
+        hulledOutline: nodeOptions.hulledOutline
       }
     };
     if (level === groupDepth) {

--- a/packages/demo-app-ts/src/demos/TopologyPackage.tsx
+++ b/packages/demo-app-ts/src/demos/TopologyPackage.tsx
@@ -26,7 +26,7 @@ import {
 import stylesComponentFactory from '../components/stylesComponentFactory';
 import defaultLayoutFactory from '../layouts/defaultLayoutFactory';
 import defaultComponentFactory from '../components/defaultComponentFactory';
-import { generateDataModel, generateEdge, generateNode } from '../data/generator';
+import { generateDataModel, generateEdge, generateNode, updateGroup } from '../data/generator';
 import { useTopologyOptions } from '../utils/useTopologyOptions';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 
@@ -157,7 +157,7 @@ const TopologyViewComponent: React.FunctionComponent<TopologyViewComponentProps>
     if (nodes.length) {
       const updatedNodes: NodeModel[] = nodes.map((node, index) => {
         if (node.group) {
-          return node;
+          return updateGroup(node, nodeOptions);
         }
         return {
           ...node,

--- a/packages/demo-app-ts/src/utils/useTopologyOptions.tsx
+++ b/packages/demo-app-ts/src/utils/useTopologyOptions.tsx
@@ -177,6 +177,14 @@ export const useTopologyOptions = (
         >
           Context Menus
         </SelectOption>
+        <SelectOption
+          hasCheckbox
+          value="Rectangle Groups"
+          isSelected={!nodeOptions.hulledOutline}
+          onClick={() => setNodeOptions((prev) => ({ ...prev, hulledOutline: !prev.hulledOutline }))}
+        >
+          Rectangle Groups
+        </SelectOption>
       </SelectList>
     );
 

--- a/packages/module/src/components/groups/DefaultGroup.tsx
+++ b/packages/module/src/components/groups/DefaultGroup.tsx
@@ -77,6 +77,8 @@ interface DefaultGroupProps {
   onContextMenu?: (e: React.MouseEvent) => void;
   /** Flag indicating that the context menu for the node is currently open  */
   contextMenuOpen?: boolean;
+  /** Flag indicating whether to use hull layout or rect layout for expanded groups. Defaults to hull (true) */
+  hulledOutline?: boolean;
 }
 
 type DefaultGroupInnerProps = Omit<DefaultGroupProps, 'element'> & { element: Node };

--- a/packages/module/src/components/groups/DefaultGroupExpanded.tsx
+++ b/packages/module/src/components/groups/DefaultGroupExpanded.tsx
@@ -123,7 +123,7 @@ const DefaultGroupExpanded: React.FunctionComponent<DefaultGroupExpandedProps> =
   const padding = maxPadding(element.getStyle<NodeStyle>().padding ?? 17);
   const hullPadding = (point: PointWithSize | PointTuple) => (point[2] || 0) + padding;
 
-  if (!droppable || !pathRef.current || !labelLocation.current) {
+  if (!droppable || (hulledOutline && !pathRef.current) || (!hulledOutline && !boxRef.current) || !labelLocation.current) {
     const children = element.getNodes().filter(c => c.isVisible());
     if (children.length === 0) {
       return null;

--- a/packages/module/src/components/groups/DefaultGroupExpanded.tsx
+++ b/packages/module/src/components/groups/DefaultGroupExpanded.tsx
@@ -99,7 +99,7 @@ const DefaultGroupExpanded: React.FunctionComponent<DefaultGroupExpandedProps> =
   labelIcon,
   labelIconPadding,
   onCollapseChange,
-  hulledOutline,
+  hulledOutline = true,
 }) => {
   const [hovered, hoverRef] = useHover();
   const [labelHover, labelHoverRef] = useHover();
@@ -111,7 +111,6 @@ const DefaultGroupExpanded: React.FunctionComponent<DefaultGroupExpandedProps> =
   const labelLocation = React.useRef<PointWithSize>();
   const pathRef = React.useRef<string>();
   const boxRef = React.useRef<Rect | null>(null);
-  const nodeElement = element as Node;
 
   let parent = element.getParent();
   let altGroup = false;
@@ -160,7 +159,7 @@ const DefaultGroupExpanded: React.FunctionComponent<DefaultGroupExpandedProps> =
       // Compute the location of the group label.
       labelLocation.current = computeLabelLocation(hullPoints as PointWithSize[]);
     } else {
-      boxRef.current = nodeElement.getBounds();
+      boxRef.current = element.getBounds();
       labelLocation.current = [boxRef.current.x + boxRef.current.width / 2, boxRef.current.y + boxRef.current.height, 0];
     }
   }


### PR DESCRIPTION
Closes https://github.com/patternfly/react-topology/issues/113

## Description
A new property in the DefaultGroup was added to set whether the outline of the group is hulled or rect.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review


