### PR TITLE
fix(build): prevent index.ts file from being copied into dist

### DIFF
--- a/packages/module/scripts/writeClassMaps.js
+++ b/packages/module/scripts/writeClassMaps.js
@@ -51,6 +51,17 @@ function writeIndex(fileName) {
   }
 }
 
+function isNotTS(file) {
+  const isTS = file.endsWith('.ts');
+  const isNotDeclaration = !file.endsWith('.d.ts');
+
+  if (isTS && isNotDeclaration) {
+    return false;
+  }
+
+  return true;
+}
+
 /**
  * @param {any} classMaps Map of file names to classMaps
  */
@@ -65,10 +76,10 @@ function writeClassMaps(classMaps) {
     copyFileSync(file, join(outDir, outPath));
 
     ensureDirSync(esmDistDir);
-    copySync(outDir, esmDistDir);
+    copySync(outDir, esmDistDir, { filter: isNotTS });
 
     ensureDirSync(jsDistDir);
-    copySync(outDir, jsDistDir);
+    copySync(outDir, jsDistDir, { filter: isNotTS });
   });
 
   // eslint-disable-next-line no-console


### PR DESCRIPTION
## What
Closes #118

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Prevents TypeScript files from being copied to the dist/{module}/css directory at build time. Still allows type declaration files to be copied.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review


