### PR TITLE
Logic for showing, scaling or hiding the tag on an edge depending on the details level of the graph

### DIFF
--- a/packages/module/src/components/edges/DefaultEdge.tsx
+++ b/packages/module/src/components/edges/DefaultEdge.tsx
@@ -113,7 +113,7 @@ const DefaultEdgeInner: React.FunctionComponent<DefaultEdgeInnerProps> = observe
     return null;
   }
 
-  const detailsLevel = useDetailsLevel();
+  const detailsLevel = element.getGraph().getDetailsLevel();
 
   const groupClassName = css(
     styles.topologyEdge,

--- a/packages/module/src/components/edges/DefaultEdge.tsx
+++ b/packages/module/src/components/edges/DefaultEdge.tsx
@@ -13,7 +13,6 @@ import { TOP_LAYER } from '../../const';
 import DefaultConnectorTag from './DefaultConnectorTag';
 import { Point } from '../../geom';
 import { getConnectorStartPoint } from './terminals/terminalUtils';
-import { useDetailsLevel } from '../../hooks';
 
 interface DefaultEdgeProps {
   /** Additional content added to the edge */


### PR DESCRIPTION
Resolves #122.

When hovering on details level != high:

![image](https://github.com/patternfly/react-topology/assets/1286393/5ba46a6f-285c-4486-b973-583e45699206)


