### PR TITLE
fix(collapse):Fix child positions on group expand

### DIFF
--- a/packages/module/src/components/groups/DefaultGroup.tsx
+++ b/packages/module/src/components/groups/DefaultGroup.tsx
@@ -3,8 +3,9 @@ import { observer } from 'mobx-react';
 import DefaultGroupExpanded from './DefaultGroupExpanded';
 import { OnSelect, WithDndDragProps, ConnectDragSource, ConnectDropTarget } from '../../behavior';
 import { BadgeLocation, GraphElement, isNode, LabelPosition, Node } from '../../types';
-import DefaultGroupCollapsed from './DefaultGroupCollapsed';
 import { ShapeProps } from '../nodes';
+import { Dimensions } from '../../geom';
+import DefaultGroupCollapsed from './DefaultGroupCollapsed';
 
 interface DefaultGroupProps {
   /** Additional classes added to the group */
@@ -91,7 +92,7 @@ const DefaultGroupInner: React.FunctionComponent<DefaultGroupInnerProps> = obser
 }) => {
   const handleCollapse = (group: Node, collapsed: boolean): void => {
     if (collapsed && rest.collapsedWidth !== undefined && rest.collapsedHeight !== undefined) {
-      group.setBounds(group.getBounds().setSize(rest.collapsedWidth, rest.collapsedHeight));
+      group.setDimensions(new Dimensions(rest.collapsedWidth, rest.collapsedHeight));
     }
     group.setCollapsed(collapsed);
     onCollapseChange && onCollapseChange(group, collapsed);

--- a/packages/module/src/elements/BaseNode.ts
+++ b/packages/module/src/elements/BaseNode.ts
@@ -199,7 +199,7 @@ export default class BaseNode<E extends NodeModel = NodeModel, D = any> extends 
   updateChildrenPositions(point: Point, prevLocation: Point): void {
     const xOffset = point.x - prevLocation.x;
     const yOffset = point.y - prevLocation.y;
-    this.getChildren().forEach(child => {
+    this.getAllNodeChildren().forEach(child => {
       if (isNode(child)) {
         const node = child as Node;
         const position = node.getPosition();


### PR DESCRIPTION
## What
Closes #145 

## Description
Fix positioning of child nodes when a collapsed group is expanded.

## Type of change
- [x] Bugfix

## Surge
https://uncollapse-fix.surge.sh