### PR TITLE
Fix(TaskNode): set nameLabelClass attribute

### DIFF
--- a/packages/module/src/pipelines/components/nodes/TaskNode.tsx
+++ b/packages/module/src/pipelines/components/nodes/TaskNode.tsx
@@ -132,6 +132,7 @@ const TaskNodeInner: React.FC<TaskNodeInnerProps> = observer(({
   badgeTooltip,
   badgePopoverProps,
   badgePopoverParams,
+  nameLabelClass,
   taskIconClass,
   taskIcon,
   taskIconTooltip,
@@ -298,7 +299,11 @@ const TaskNodeInner: React.FC<TaskNodeInnerProps> = observer(({
   const { translateX, translateY } = getNodeScaleTranslation(element, nodeScale, scaleNode);
 
   const nameLabel = (
-    <text ref={nameLabelRef} className={css(styles.topologyPipelinesPillText)} dominantBaseline="middle">
+    <text
+      ref={nameLabelRef}
+      className={css(nameLabelClass, styles.topologyPipelinesPillText)}
+      dominantBaseline="middle"
+    >
       {label}
     </text>
   );

--- a/packages/module/src/pipelines/decorators/WhenDecorator.tsx
+++ b/packages/module/src/pipelines/decorators/WhenDecorator.tsx
@@ -25,7 +25,7 @@ interface WhenDecoratorProps {
   width?: number;
   /** Height of the when decorator */
   height?: number;
-  /** Additional classes added to the label */
+  /** @deprecated Additional classes added to the label */
   nameLabelClass?: string;
   /** WhenStatus to depict */
   status?: WhenStatus;


### PR DESCRIPTION
## What
Closes #151

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Set nameLabelClass attribute on TaskNode
- Marked prop as deprecated in WhenDecorator

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):



