### PR TITLE
fix(deps): Move @types/react from resolutions to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,7 @@
     "react-dom": "^18",
     "serve": "^14.1.2",
     "surge": "^0.23.1",
-    "typedoc": "0.23"
-  },
-  "resolutions": {
+    "typedoc": "0.23",
     "@types/react": "^18"
   }
 }


### PR DESCRIPTION
## What
Might resolve the issue with #165

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Moves react types dependency to devDeps because of an issue Openshift is having with react types after testing the latest topology prerelease.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):
Dependency adjustment.

## Screen shots / Gifs for design review


