### PR TITLE
feat(pipelines): Add ability to scale collapsed pipeline groups

### DIFF
--- a/packages/demo-app-ts/src/demos/pipelineGroupsDemo/DemoTaskGroup.tsx
+++ b/packages/demo-app-ts/src/demos/pipelineGroupsDemo/DemoTaskGroup.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import {
-  AnchorEnd,
   DagreLayoutOptions,
   DefaultTaskGroup,
   GraphElement,
@@ -9,27 +8,18 @@ import {
   LabelPosition,
   Node,
   TOP_TO_BOTTOM,
-  useAnchor,
-  WithContextMenuProps,
   WithSelectionProps,
-  ShapeProps,
-  WithDragNodeProps,
   EdgeCreationTypes,
+  useHover,
+  ScaleDetailsLevel,
+  DEFAULT_LAYER,
+  Layer,
+  TOP_LAYER, GROUPS_LAYER
 } from '@patternfly/react-topology';
-import TaskGroupSourceAnchor from './TaskGroupSourceAnchor';
-import TaskGroupTargetAnchor from './TaskGroupTargetAnchor';
 
 type DemoTaskGroupProps = {
   element: GraphElement;
-  collapsible?: boolean;
-  collapsedWidth?: number;
-  collapsedHeight?: number;
-  onCollapseChange?: (group: Node, collapsed: boolean) => void;
-  getCollapsedShape?: (node: Node) => React.FunctionComponent<ShapeProps>;
-  collapsedShadowOffset?: number; // defaults to 10
-} & WithContextMenuProps &
-  WithDragNodeProps &
-  WithSelectionProps;
+} & WithSelectionProps;
 
 export const DEFAULT_TASK_WIDTH = 180;
 export const DEFAULT_TASK_HEIGHT = 32;
@@ -41,29 +31,32 @@ const getEdgeCreationTypes = (): EdgeCreationTypes => ({
 
 const DemoTaskGroup: React.FunctionComponent<DemoTaskGroupProps> = ({ element, ...rest }) => {
   const verticalLayout = (element.getGraph().getLayoutOptions?.() as DagreLayoutOptions)?.rankdir === TOP_TO_BOTTOM;
+  const [hover, hoverRef] = useHover();
+  const detailsLevel = element.getGraph().getDetailsLevel();
 
-  useAnchor(
-    React.useCallback((node: Node) => new TaskGroupSourceAnchor(node, verticalLayout), [verticalLayout]),
-    AnchorEnd.source
-  );
-  useAnchor(
-    React.useCallback((node: Node) => new TaskGroupTargetAnchor(node, verticalLayout), [verticalLayout]),
-    AnchorEnd.target
-  );
   if (!isNode(element)) {
     return null;
   }
+  const groupLayer = element.isCollapsed() ? DEFAULT_LAYER : GROUPS_LAYER;
+
   return (
-    <DefaultTaskGroup
-      labelPosition={verticalLayout ? LabelPosition.top : LabelPosition.bottom}
-      collapsible
-      collapsedWidth={DEFAULT_TASK_WIDTH}
-      collapsedHeight={DEFAULT_TASK_HEIGHT}
-      element={element as Node}
-      recreateLayoutOnCollapseChange
-      getEdgeCreationTypes={getEdgeCreationTypes}
-      {...rest}
-    />
+    <Layer id={detailsLevel !== ScaleDetailsLevel.high && hover ? TOP_LAYER : groupLayer}>
+      <g ref={hoverRef}>
+        <DefaultTaskGroup
+          labelPosition={verticalLayout ? LabelPosition.top : LabelPosition.bottom}
+          collapsible
+          collapsedWidth={DEFAULT_TASK_WIDTH}
+          collapsedHeight={DEFAULT_TASK_HEIGHT}
+          element={element as Node}
+          recreateLayoutOnCollapseChange
+          getEdgeCreationTypes={getEdgeCreationTypes}
+          scaleNode={hover && detailsLevel !== ScaleDetailsLevel.high}
+          showLabel={detailsLevel === ScaleDetailsLevel.high}
+          hideDetailsAtMedium
+          {...rest}
+        />
+      </g>
+    </Layer>
   );
 };
 

--- a/packages/module/src/pipelines/components/anchors/TaskGroupSourceAnchor.ts
+++ b/packages/module/src/pipelines/components/anchors/TaskGroupSourceAnchor.ts
@@ -1,9 +1,11 @@
-import { AbstractAnchor, Point, Node } from '@patternfly/react-topology';
+import { AbstractAnchor } from '../../../anchors';
+import { Point } from '../../../geom';
+import { Node } from '../../../types';
 
-export default class TaskGroupSourceAnchor<E extends Node = Node> extends AbstractAnchor {
+export default class TaskGroupSourceAnchor extends AbstractAnchor {
   private vertical = false;
 
-  constructor(owner: E, vertical: boolean = true) {
+  constructor(owner: Node, vertical: boolean = true) {
     super(owner);
     this.vertical = vertical;
   }

--- a/packages/module/src/pipelines/components/anchors/TaskGroupTargetAnchor.ts
+++ b/packages/module/src/pipelines/components/anchors/TaskGroupTargetAnchor.ts
@@ -1,9 +1,11 @@
-import { AbstractAnchor, Point, Node } from '@patternfly/react-topology';
+import { AbstractAnchor } from '../../../anchors';
+import { Node } from '../../../types';
+import { Point } from '../../../geom';
 
-export default class TaskGroupTargetAnchor<E extends Node = Node> extends AbstractAnchor {
+export default class TaskGroupTargetAnchor extends AbstractAnchor {
   private vertical = false;
 
-  constructor(owner: E, vertical = false) {
+  constructor(owner: Node, vertical = false) {
     super(owner);
     this.vertical = vertical;
   }

--- a/packages/module/src/pipelines/components/anchors/index.ts
+++ b/packages/module/src/pipelines/components/anchors/index.ts
@@ -1,2 +1,4 @@
 export { default as TaskNodeSourceAnchor } from './TaskNodeSourceAnchor';
 export { default as TaskNodeTargetAnchor } from './TaskNodeTargetAnchor';
+export { default as TaskGroupSourceAnchor } from './TaskGroupSourceAnchor';
+export { default as TaskGroupTargetAnchor } from './TaskGroupTargetAnchor';

--- a/packages/module/src/pipelines/components/groups/DefaultTaskGroupCollapsed.tsx
+++ b/packages/module/src/pipelines/components/groups/DefaultTaskGroupCollapsed.tsx
@@ -1,38 +1,19 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-alt-icon';
-import { WithDragNodeProps, WithSelectionProps, WithDndDropProps, WithContextMenuProps } from '../../../behavior';
 import { CollapsibleGroupProps } from "../../../components";
-import { LabelPosition, BadgeLocation, Node } from '../../../types';
+import { Node } from '../../../types';
 import { TaskNode } from '../nodes';
+import { TaskNodeProps } from '../nodes/TaskNode';
 
-type DefaultTaskGroupCollapsedProps = {
-  children?: React.ReactNode;
-  className?: string;
+export type DefaultTaskGroupCollapsedProps = {
   element: Node;
-  droppable?: boolean;
-  canDrop?: boolean;
-  dropTarget?: boolean;
-  dragging?: boolean;
-  hover?: boolean;
-  label?: string; // Defaults to element.getLabel()
-  secondaryLabel?: string;
-  showLabel?: boolean; // Defaults to true
-  labelPosition?: LabelPosition; // Defaults to bottom
-  truncateLength?: number; // Defaults to 13
-  labelIconClass?: string; // Icon to show in label
-  labelIcon?: string;
-  labelIconPadding?: number;
-  badge?: string;
-  badgeColor?: string;
-  badgeTextColor?: string;
-  badgeBorderColor?: string;
-  badgeClassName?: string;
-  badgeLocation?: BadgeLocation;
-} & CollapsibleGroupProps & WithDragNodeProps & WithSelectionProps & WithDndDropProps & WithContextMenuProps;
+  shadowCount?: number;
+} & Omit<TaskNodeProps, 'element'> & CollapsibleGroupProps;
 
 const DefaultTaskGroupCollapsed: React.FunctionComponent<DefaultTaskGroupCollapsedProps> = ({
   element,
+  shadowCount = 2,
   collapsible,
   onCollapseChange,
   ...rest
@@ -43,7 +24,8 @@ const DefaultTaskGroupCollapsed: React.FunctionComponent<DefaultTaskGroupCollaps
       element={element} {...rest}
       actionIcon={collapsible ? <ExpandIcon /> : undefined}
       onActionIconClick={() => onCollapseChange(element, false)}
-      shadowCount={2}
+      shadowCount={shadowCount}
+      {...rest}
     />
   );
 };

--- a/packages/module/src/pipelines/components/groups/DefaultTaskGroupExpanded.tsx
+++ b/packages/module/src/pipelines/components/groups/DefaultTaskGroupExpanded.tsx
@@ -7,44 +7,24 @@ import NodeLabel from '../../../components/nodes/labels/NodeLabel';
 import { Layer } from '../../../components/layers';
 import { GROUPS_LAYER, TOP_LAYER } from '../../../const';
 import { maxPadding, useCombineRefs, useHover } from '../../../utils';
-import { BadgeLocation, GraphElement, isGraph, LabelPosition, Node, NodeStyle } from '../../../types';
 import {
+  AnchorEnd,
+  isGraph,
+  LabelPosition,
+  Node,
+  NodeStyle
+} from '../../../types';
+import {
+  useAnchor,
   useDragNode,
-  WithContextMenuProps,
-  WithDndDropProps,
-  WithDragNodeProps,
-  WithSelectionProps
 } from '../../../behavior';
-import { CollapsibleGroupProps } from '../../../components';
+import { DagreLayoutOptions, TOP_TO_BOTTOM } from '../../../layouts';
+import TaskGroupSourceAnchor from '../anchors/TaskGroupSourceAnchor';
+import TaskGroupTargetAnchor from '../anchors/TaskGroupTargetAnchor';
+// import { action } from 'mobx';
+import { DefaultTaskGroupProps } from './DefaultTaskGroup';
 
-type DefaultTaskGroupProps = {
-  className?: string;
-  element: GraphElement;
-  droppable?: boolean;
-  canDrop?: boolean;
-  dropTarget?: boolean;
-  dragging?: boolean;
-  hover?: boolean;
-  label?: string; // Defaults to element.getLabel()
-  secondaryLabel?: string;
-  showLabel?: boolean; // Defaults to true
-  labelPosition?: LabelPosition;
-  truncateLength?: number; // Defaults to 13
-  badge?: string;
-  badgeColor?: string;
-  badgeTextColor?: string;
-  badgeBorderColor?: string;
-  badgeClassName?: string;
-  badgeLocation?: BadgeLocation;
-  labelOffset?: number; // Space between the label and the group
-  labelIconClass?: string; // Icon to show in label
-  labelIcon?: string;
-  labelIconPadding?: number;
-} & Partial<CollapsibleGroupProps & WithDragNodeProps & WithSelectionProps & WithDndDropProps & WithContextMenuProps>;
-
-type DefaultTaskGroupInnerProps = Omit<DefaultTaskGroupProps, 'element'> & { element: Node };
-
-const DefaultTaskGroupExpanded: React.FunctionComponent<DefaultTaskGroupInnerProps> = observer(
+const DefaultTaskGroupExpanded: React.FunctionComponent<Omit<DefaultTaskGroupProps, 'element'> & { element: Node }> = observer(
   ({
      className,
      element,
@@ -72,7 +52,7 @@ const DefaultTaskGroupExpanded: React.FunctionComponent<DefaultTaskGroupInnerPro
      labelIconClass,
      labelIcon,
      labelIconPadding,
-     onCollapseChange
+     onCollapseChange,
    }) => {
     const [hovered, hoverRef] = useHover();
     const [labelHover, labelHoverRef] = useHover();
@@ -80,6 +60,7 @@ const DefaultTaskGroupExpanded: React.FunctionComponent<DefaultTaskGroupInnerPro
     const refs = useCombineRefs<SVGPathElement>(hoverRef, dragNodeRef);
     const isHover = hover !== undefined ? hover : hovered;
     const labelPosition = element.getLabelPosition();
+    const verticalLayout = (element.getGraph().getLayoutOptions?.() as DagreLayoutOptions)?.rankdir === TOP_TO_BOTTOM;
 
     let parent = element.getParent();
     let altGroup = false;
@@ -87,6 +68,15 @@ const DefaultTaskGroupExpanded: React.FunctionComponent<DefaultTaskGroupInnerPro
       altGroup = !altGroup;
       parent = parent.getParent();
     }
+
+    useAnchor(
+      React.useCallback((node: Node) => new TaskGroupSourceAnchor(node, verticalLayout), [verticalLayout]),
+      AnchorEnd.source
+    );
+    useAnchor(
+      React.useCallback((node: Node) => new TaskGroupTargetAnchor(node, verticalLayout), [verticalLayout]),
+      AnchorEnd.target
+    );
 
     const children = element.getNodes().filter((c) => c.isVisible());
 

--- a/packages/module/src/pipelines/components/groups/DefaultTaskGroupExpanded.tsx
+++ b/packages/module/src/pipelines/components/groups/DefaultTaskGroupExpanded.tsx
@@ -21,7 +21,6 @@ import {
 import { DagreLayoutOptions, TOP_TO_BOTTOM } from '../../../layouts';
 import TaskGroupSourceAnchor from '../anchors/TaskGroupSourceAnchor';
 import TaskGroupTargetAnchor from '../anchors/TaskGroupTargetAnchor';
-// import { action } from 'mobx';
 import { DefaultTaskGroupProps } from './DefaultTaskGroup';
 
 const DefaultTaskGroupExpanded: React.FunctionComponent<Omit<DefaultTaskGroupProps, 'element'> & { element: Node }> = observer(

--- a/packages/module/src/pipelines/components/groups/index.ts
+++ b/packages/module/src/pipelines/components/groups/index.ts
@@ -1,2 +1,4 @@
-export { default as DefaultTaskGroup } from './DefaultTaskGroup';
 export type { EdgeCreationTypes } from './DefaultTaskGroup';
+export { default as DefaultTaskGroup } from './DefaultTaskGroup';
+export { default as DefaultTaskGroupExpanded } from './DefaultTaskGroupExpanded';
+export { default as DefaultTaskGroupCollapsed } from './DefaultTaskGroupCollapsed';

--- a/packages/module/src/pipelines/components/nodes/TaskNode.tsx
+++ b/packages/module/src/pipelines/components/nodes/TaskNode.tsx
@@ -318,7 +318,7 @@ const TaskNodeInner: React.FC<TaskNodeInnerProps> = observer(({
     return action(() => {
       sourceEdges.forEach(edge => {
         const data = edge.getData();
-        if (data.indent) {
+        if (data?.indent) {
           edge.setData({...(data || {}), indent: 0});
         }
       });

--- a/packages/module/src/pipelines/components/nodes/TaskNode.tsx
+++ b/packages/module/src/pipelines/components/nodes/TaskNode.tsx
@@ -233,7 +233,8 @@ const TaskNodeInner: React.FC<TaskNodeInnerProps> = observer(({
         badgeStartX: 0,
         iconWidth: 0,
         iconStartX: 0,
-        leadIconStartX: 0
+        leadIconStartX: 0,
+        offsetX: 0
       };
     }
     const height: number = textHeight + 2 * paddingY;
@@ -303,16 +304,25 @@ const TaskNodeInner: React.FC<TaskNodeInnerProps> = observer(({
   ]);
 
   React.useEffect(() => {
+    const sourceEdges = element.getSourceEdges();
     action(() => {
-      const sourceEdges = element.getSourceEdges();
+      const indent = detailsLevel === ScaleDetailsLevel.high && !verticalLayout ? width - pillWidth : 0;
       sourceEdges.forEach(edge => {
         const data = edge.getData();
-        edge.setData({
-          ...(data || {}),
-          indent: detailsLevel === ScaleDetailsLevel.high && !verticalLayout ? width - pillWidth : 0
-        });
+        if ((data?.indent ?? 0) !== indent) {
+          edge.setData({ ...(data || {}), indent });
+        }
       });
     })();
+
+    return action(() => {
+      sourceEdges.forEach(edge => {
+        const data = edge.getData();
+        if (data.indent) {
+          edge.setData({...(data || {}), indent: 0});
+        }
+      });
+    });
   }, [detailsLevel, element, pillWidth, verticalLayout, width]);
 
   const scale = element.getGraph().getScale();


### PR DESCRIPTION
## What
Closes #172 

## Description
Add ability to hide details of collapsed pipeline groups. Also fixes some edge alignment issues caused by collapsing and re-expanding the pipeline groups.

## Type of change
- [x ] Feature
