### PR TITLE
feat(pipelines): Add ability and styling for selected task edges

### DIFF
--- a/packages/demo-app-ts/src/demos/pipelineGroupsDemo/DemoTaskEdge.tsx
+++ b/packages/demo-app-ts/src/demos/pipelineGroupsDemo/DemoTaskEdge.tsx
@@ -5,10 +5,11 @@ import {
   Edge,
   EdgeTerminalType,
   GraphElement,
-  TaskEdge
+  TaskEdge,
+  WithSelectionProps
 } from '@patternfly/react-topology';
 
-interface DemoTaskEdgeProps {
+interface DemoTaskEdgeProps extends WithSelectionProps {
   element: GraphElement;
 }
 

--- a/packages/demo-app-ts/src/demos/pipelineGroupsDemo/PipelineGroupsDemo.tsx
+++ b/packages/demo-app-ts/src/demos/pipelineGroupsDemo/PipelineGroupsDemo.tsx
@@ -21,6 +21,8 @@ import {
   useVisualizationController,
   addSpacerNodes,
   pipelineElementFactory,
+  isEdge,
+  Edge,
 } from '@patternfly/react-topology';
 import pipelineGroupsComponentFactory from './pipelineGroupsComponentFactory';
 import {
@@ -37,6 +39,25 @@ const TopologyPipelineGroups: React.FC<{ nodes: PipelineNodeModel[] }> = observe
   const [selectedIds, setSelectedIds] = React.useState<string[]>();
 
   useEventListener<SelectionEventListener>(SELECTION_EVENT, ids => {
+    if (ids?.[0]) {
+      const element = controller?.getElementById(ids[0]);
+      if (element && isEdge(element)) {
+        const edge = element as Edge;
+        const selectedEdges = [edge.getId()];
+        const source = edge.getSource();
+        const target = edge.getTarget();
+        if (source.getType() === DEFAULT_SPACER_NODE_TYPE) {
+          const sourceEdges = source.getTargetEdges();
+          selectedEdges.push(...sourceEdges.map((e) => e.getId()));
+        }
+        if (target.getType() === DEFAULT_SPACER_NODE_TYPE) {
+          const targetEdges = target.getSourceEdges();
+          selectedEdges.push(...targetEdges.map((e) => e.getId()));
+        }
+        setSelectedIds(selectedEdges);
+        return;
+      }
+    }
     setSelectedIds(ids);
   });
 

--- a/packages/demo-app-ts/src/demos/pipelineGroupsDemo/pipelineGroupsComponentFactory.tsx
+++ b/packages/demo-app-ts/src/demos/pipelineGroupsDemo/pipelineGroupsComponentFactory.tsx
@@ -18,7 +18,7 @@ const pipelineGroupsComponentFactory: ComponentFactory = (
   type: string
 ): React.ComponentType<{ element: GraphElement }> | undefined => {
   if (kind === ModelKind.graph) {
-    return withPanZoom()(GraphComponent);
+    return withPanZoom()(withSelection()(GraphComponent));
   }
   switch (type) {
     case 'Execution':
@@ -32,7 +32,7 @@ const pipelineGroupsComponentFactory: ComponentFactory = (
       return SpacerNode;
     case 'edge':
       // draw arrow terminal when isDependency is set on data
-      return DemoTaskEdge;
+      return withSelection()(DemoTaskEdge);
     default:
       return undefined;
   }

--- a/packages/module/src/css/topology-components.css
+++ b/packages/module/src/css/topology-components.css
@@ -622,7 +622,7 @@
   --edge--stroke: var(--pf-topology__edge--Stroke);
   --edge--fill: var(--edge--stroke);
   --edge--opacity: 1;
-  --edge--cursor: pointer;
+  --edge--cursor: default;
   --edge--hover--stroke: var(--pf-topology__edge--HoverStroke);
   --edge--hover--fill: var(--edge--hover--stroke);
   --edge--active--stroke: var(--pf-topology__edge--ActiveStroke);
@@ -635,13 +635,15 @@
 
   cursor: var(--edge--cursor);
   stroke: var(--edge--stroke);
-  fill: var(--edge--fill);
+  fill: none;
   opacity: var(--edge--opacity);
 }
 
+.pf-topology__edge.pf-m-selectable {
+  --edge--cursor: pointer;
+}
 .pf-topology__edge.pf-m-info {
   --edge--stroke: var(--pf-topology__edge--m-info--EdgeStroke);
-  --edge--fill: var(--pf-v5-global--primary-color--light-100);
 }
 
 .pf-topology__edge.pf-m-success {
@@ -662,6 +664,10 @@
   stroke-width: 10px;
   stroke: transparent;
   fill: none;
+  cursor: var(--edge--cursor);
+}
+.pf-topology__edge__background.pf-m-selectable {
+  cursor: pointer;
 }
 .pf-topology__edge.pf-m-selected .pf-topology__edge__background {
   stroke: var(--pf-topology__edge--m-selected--background--Stroke);
@@ -673,9 +679,10 @@
 .pf-topology__edge__link {
   stroke-width: var(--edge--stroke-width);
   stroke-dasharray: var(--edge--stroke-dasharray);
-  fill-opacity: 0;
   animation: pf-topology__edge__dash 0s linear infinite forwards;
- }
+  --edge--cursor: pointer;
+  fill: none;
+}
 
 .pf-topology__edge__link.pf-m-dotted {
   stroke-dasharray: 2;
@@ -706,15 +713,19 @@
 
 .pf-topology__edge.pf-m-selected .pf-topology__edge__link,
 .pf-topology__edge.pf-m-selected .pf-topology-connector-arrow {
-  fill: var(--edge--active--fill);
   stroke: var(--edge--active--stroke);
   stroke-width: var(--edge--active--stroke-width);
+}
+.pf-topology__edge.pf-m-selected .pf-topology-connector-arrow {
+  fill: var(--edge--active--fill);
 }
 
 .pf-topology__edge.pf-m-selected.pf-m-hover .pf-topology__edge__link,
 .pf-topology__edge.pf-m-selected.pf-m-hover .pf-topology-connector-arrow {
-  fill: var(--edge--active--fill);
   stroke: var(--edge--active--stroke);
+}
+.pf-topology__edge.pf-m-selected.pf-m-hover .pf-topology-connector-arrow {
+  fill: var(--edge--active--fill);
 }
 
 .pf-topology__edge.pf-m-dragging {
@@ -722,14 +733,18 @@
 }
 .pf-topology__edge.pf-m-hover .pf-topology__edge__link,
 .pf-topology__edge.pf-m-hover .pf-topology-connector-arrow {
-  fill: var(--edge--hover--fill);
   stroke: var(--edge--hover--stroke);
+}
+.pf-topology__edge.pf-m-hover .pf-topology-connector-arrow {
+  fill: var(--edge--hover--fill);
 }
 
 .pf-topology__edge.pf-m-dragging .pf-topology__edge__link,
 .pf-topology__edge.pf-m-dragging .pf-topology-connector-arrow {
-  fill: var(--edge--interactive--fill);
   stroke: var(--edge--interactive--stroke);
+}
+.pf-topology__edge.pf-m-dragging .pf-topology-connector-arrow {
+  fill: var(--edge--interactive--fill);
 }
 
 .pf-topology__edge .pf-topology-connector-arrow {
@@ -779,6 +794,7 @@
 .pf-topology-connector-arrow {
   stroke-width: 1;
   stroke: var(--edge--stroke);
+  fill: var(--edge--fill)
 }
 
 .pf-topology-connector-arrow.pf-m-alt-connector-arrow {


### PR DESCRIPTION
## What
Closes #187 

## Description
Adds `WithSelection` props to `TaskEdge` and styles for selection.

## Type of change
- [x] Feature

## Screen shots / Gifs for design review
![image](https://github.com/patternfly/react-topology/assets/11633780/19d04b07-bef0-4a97-ba05-933e19f5ada8)

![image](https://github.com/patternfly/react-topology/assets/11633780/849b9743-357d-4268-a1e3-4c73efe08eda)


