### PR TITLE
fix(target arrow): Correctly determine incoming point for target connectors

### DIFF
--- a/packages/module/src/components/edges/terminals/DefaultConnectorTerminal.tsx
+++ b/packages/module/src/components/edges/terminals/DefaultConnectorTerminal.tsx
@@ -60,7 +60,7 @@ const DefaultConnectorTerminal: React.FunctionComponent<EdgeConnectorArrowProps>
   }
   const bendPoints = edge.getBendpoints();
   const defaultStartPoint = isTarget
-    ? edge.getBendpoints[bendPoints.length - 1] || edge.getStartPoint()
+    ? bendPoints[bendPoints.length - 1] || edge.getStartPoint()
     : bendPoints[0] || edge.getEndPoint();
   const defaultEndPoint = isTarget ? edge.getEndPoint() : edge.getStartPoint();
   const classes = css(styles.topologyEdge, className, StatusModifier[status]);


### PR DESCRIPTION
## What
Closes #190

## Description
Fix error in determination of incoming location for target arrows on edges with bendpoints.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review
![image](https://github.com/patternfly/react-topology/assets/11633780/5ff9a2f5-91f8-4415-a560-6aa7fc3ca7bf)


