### PR TITLE
feat(ControlBar): Add expand/collapse all buttons

### DIFF
--- a/packages/demo-app-ts/src/demos/DemoControlBar.tsx
+++ b/packages/demo-app-ts/src/demos/DemoControlBar.tsx
@@ -7,13 +7,17 @@ import {
   action
 } from '@patternfly/react-topology';
 
-const DemoControlBar: React.FC = () => {
+const DemoControlBar: React.FC<{ collapseAllCallback?: (collapseAll: boolean) => void }> = ({
+  collapseAllCallback
+}) => {
   const controller = useVisualizationController();
 
   return (
     <TopologyControlBar
       controlButtons={createTopologyControlButtons({
         ...defaultControlButtonsOptions,
+        expandAll: !!collapseAllCallback,
+        collapseAll: !!collapseAllCallback,
         zoomInCallback: action(() => {
           controller.getGraph().scaleBy(4 / 3);
         }),
@@ -26,6 +30,12 @@ const DemoControlBar: React.FC = () => {
         resetViewCallback: action(() => {
           controller.getGraph().reset();
           controller.getGraph().layout();
+        }),
+        expandAllCallback: action(() => {
+          collapseAllCallback(false);
+        }),
+        collapseAllCallback: action(() => {
+          collapseAllCallback(true);
         }),
         legend: false
       })}

--- a/packages/module/src/components/TopologyControlBar/TopologyControlBar.tsx
+++ b/packages/module/src/components/TopologyControlBar/TopologyControlBar.tsx
@@ -12,6 +12,9 @@ import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
 import ExpandArrowsAltIcon from '@patternfly/react-icons/dist/esm/icons/expand-arrows-alt-icon';
 import SearchPlusIcon from '@patternfly/react-icons/dist/esm/icons/search-plus-icon';
 import SearchMinusIcon from '@patternfly/react-icons/dist/esm/icons/search-minus-icon';
+import CollapseIcon from '@patternfly/react-icons/dist/esm/icons/compress-alt-icon';
+import ExpandAltIcon from '@patternfly/react-icons/dist/esm/icons/expand-alt-icon';
+
 import '../../css/topology-controlbar';
 
 /* ID's for common control buttons */
@@ -19,6 +22,8 @@ export const ZOOM_IN = 'zoom-in';
 export const ZOOM_OUT = 'zoom-out';
 export const FIT_TO_SCREEN = 'fit-to-screen';
 export const RESET_VIEW = 'reset-view';
+export const EXPAND_ALL = 'expand-all';
+export const COLLAPSE_ALL = 'collapse-all';
 export const LEGEND = 'legend';
 
 /* Data needed for each control button */
@@ -66,6 +71,22 @@ export interface TopologyControlButtonsOptions {
   resetViewDisabled: boolean;
   resetViewHidden: boolean;
 
+  expandAll: boolean;
+  expandAllIcon: React.ReactNode;
+  expandAllTip: React.ReactNode;
+  expandAllAriaLabel: string;
+  expandAllCallback: (id: any) => void;
+  expandAllDisabled: boolean;
+  expandAllHidden: boolean;
+
+  collapseAll: boolean;
+  collapseAllIcon: React.ReactNode;
+  collapseAllTip: React.ReactNode;
+  collapseAllAriaLabel: string;
+  collapseAllCallback: (id: any) => void;
+  collapseAllDisabled: boolean;
+  collapseAllHidden: boolean;
+
   legend: boolean;
   legendIcon: React.ReactNode;
   legendTip: string;
@@ -111,6 +132,22 @@ export const defaultControlButtonsOptions: TopologyControlButtonsOptions = {
   resetViewDisabled: false,
   resetViewHidden: false,
 
+  expandAll: false,
+  expandAllIcon: <ExpandAltIcon />,
+  expandAllTip: 'Expand All',
+  expandAllAriaLabel: 'Expand All',
+  expandAllCallback: null,
+  expandAllDisabled: false,
+  expandAllHidden: false,
+
+  collapseAll: false,
+  collapseAllIcon: <CollapseIcon />,
+  collapseAllTip: 'Collapse All',
+  collapseAllAriaLabel: 'Collapse All',
+  collapseAllCallback: null,
+  collapseAllDisabled: false,
+  collapseAllHidden: false,
+
   legend: true,
   legendIcon: 'Legend',
   legendTip: '',
@@ -155,6 +192,22 @@ export const createTopologyControlButtons = ({
   resetViewCallback = defaultControlButtonsOptions.resetViewCallback,
   resetViewDisabled = defaultControlButtonsOptions.resetViewDisabled,
   resetViewHidden = defaultControlButtonsOptions.resetViewHidden,
+
+  expandAll = defaultControlButtonsOptions.expandAll,
+  expandAllIcon = defaultControlButtonsOptions.expandAllIcon,
+  expandAllTip = defaultControlButtonsOptions.expandAllTip,
+  expandAllAriaLabel = defaultControlButtonsOptions.expandAllAriaLabel,
+  expandAllCallback = defaultControlButtonsOptions.expandAllCallback,
+  expandAllDisabled = defaultControlButtonsOptions.expandAllDisabled,
+  expandAllHidden = defaultControlButtonsOptions.expandAllHidden,
+
+  collapseAll = defaultControlButtonsOptions.collapseAll,
+  collapseAllIcon = defaultControlButtonsOptions.collapseAllIcon,
+  collapseAllTip = defaultControlButtonsOptions.collapseAllTip,
+  collapseAllAriaLabel = defaultControlButtonsOptions.collapseAllAriaLabel,
+  collapseAllCallback = defaultControlButtonsOptions.collapseAllCallback,
+  collapseAllDisabled = defaultControlButtonsOptions.collapseAllDisabled,
+  collapseAllHidden = defaultControlButtonsOptions.collapseAllHidden,
 
   legend = defaultControlButtonsOptions.legend,
   legendIcon = defaultControlButtonsOptions.legendIcon,
@@ -213,6 +266,30 @@ export const createTopologyControlButtons = ({
       callback: resetViewCallback,
       disabled: resetViewDisabled,
       hidden: resetViewHidden
+    });
+  }
+
+  if (expandAll) {
+    controlButtons.push({
+      id: EXPAND_ALL,
+      icon: expandAllIcon,
+      tooltip: expandAllTip,
+      ariaLabel: expandAllAriaLabel,
+      callback: expandAllCallback,
+      disabled: expandAllDisabled,
+      hidden: expandAllHidden
+    });
+  }
+
+  if (collapseAll) {
+    controlButtons.push({
+      id: COLLAPSE_ALL,
+      icon: collapseAllIcon,
+      tooltip: collapseAllTip,
+      ariaLabel: collapseAllAriaLabel,
+      callback: collapseAllCallback,
+      disabled: collapseAllDisabled,
+      hidden: collapseAllHidden
     });
   }
 

--- a/packages/module/src/elements/BaseGraph.ts
+++ b/packages/module/src/elements/BaseGraph.ts
@@ -226,6 +226,34 @@ export default class BaseGraph<E extends GraphModel = GraphModel, D = any>
     this.setPosition(new Point(0, 0));
   }
 
+  setAllChildrenCollapsedState(parent: Node, collapsed: boolean): void {
+    // eslint-disable-next-line no-console
+    console.log(parent.getAllNodeChildren(false));
+    parent.getAllNodeChildren(false).forEach((node) => {
+      if (node.isGroup()) {
+        node.setCollapsed(collapsed);
+      }
+    });
+  }
+
+  expandAll(): void {
+    this.getNodes().forEach((node) => {
+      if (node.isGroup()) {
+        node.setCollapsed(false);
+        this.setAllChildrenCollapsedState(node, false);
+      }
+    });
+  }
+
+  collapseAll(): void {
+    this.getNodes().forEach((node) => {
+      if (node.isGroup()) {
+        node.setCollapsed(true);
+        this.setAllChildrenCollapsedState(node, true);
+      }
+    });
+  }
+
   scaleBy(scale: number, location?: Point): void {
     const b = this.getBounds();
     let { x, y } = b;

--- a/packages/module/src/elements/BaseNode.ts
+++ b/packages/module/src/elements/BaseNode.ts
@@ -157,12 +157,15 @@ export default class BaseNode<E extends NodeModel = NodeModel, D = any>
     return super.getChildren();
   }
 
-  // Return all child leaf nodes regardless of collapse status or child groups' collapsed status
-  getAllNodeChildren(): Node[] {
+  // Return all child nodes regardless of collapse status or child groups' collapsed status
+  getAllNodeChildren(leafOnly: boolean = true): Node[] {
     return super.getChildren().reduce((total, nexChild) => {
       if (isNode(nexChild)) {
         if (nexChild.isGroup()) {
-          return total.concat(nexChild.getAllNodeChildren());
+          total.push(...nexChild.getAllNodeChildren(leafOnly));
+          if (leafOnly) {
+            return total;
+          }
         }
         total.push(nexChild);
       }

--- a/packages/module/src/pipelines/components/groups/DefaultTaskGroup.tsx
+++ b/packages/module/src/pipelines/components/groups/DefaultTaskGroup.tsx
@@ -9,6 +9,7 @@ import { getEdgesFromNodes, getSpacerNodes } from '../../utils';
 import DefaultTaskGroupCollapsed from './DefaultTaskGroupCollapsed';
 import DefaultTaskGroupExpanded from './DefaultTaskGroupExpanded';
 import { RunStatus } from '../../types';
+import { DEFAULT_SPACER_NODE_TYPE } from '../../const';
 
 export interface EdgeCreationTypes {
   spacerNodeType?: string;
@@ -145,7 +146,7 @@ const DefaultTaskGroupInner: React.FunctionComponent<PipelinesDefaultGroupInnerP
           const creationTypes: EdgeCreationTypes = getEdgeCreationTypes ? getEdgeCreationTypes() : {};
 
           const pipelineNodes = model.nodes
-            .filter((n) => n.type !== creationTypes.spacerNodeType)
+            .filter((n) => n.type !== (creationTypes.spacerNodeType || DEFAULT_SPACER_NODE_TYPE))
             .map((n) => ({
               ...n,
               visible: true

--- a/packages/module/src/types.ts
+++ b/packages/module/src/types.ts
@@ -232,7 +232,7 @@ export interface Node<E extends NodeModel = NodeModel, D = any> extends GraphEle
   setNodeStatus(shape: NodeStatus): void;
   getSourceEdges(): Edge[];
   getTargetEdges(): Edge[];
-  getAllNodeChildren(): Node[]; // Return all children regardless of collapse status or child groups' collapsed status
+  getAllNodeChildren(leafOnly?: boolean): Node[]; // Return all children regardless of collapse status or child groups' collapsed status
   getPositionableChildren(): Node[]; // Return all children that can be positioned (collapsed groups are positionable)
   isDimensionsInitialized(): boolean;
   isPositioned(): boolean;
@@ -287,6 +287,8 @@ export interface Graph<E extends GraphModel = GraphModel, D = any> extends Graph
   fit(padding?: number): void;
   panIntoView(element: Node, options?: { offset?: number; minimumVisible?: number }): void;
   isNodeInView(element: Node, options?: { padding: number }): boolean;
+  expandAll(): void;
+  collapseAll(): void;
 }
 
 export const isGraph = (element: GraphElement): element is Graph => element && element.getKind() === ModelKind.graph;


### PR DESCRIPTION
## What
Closes #196 

## Description
Adds the ability for applications to show an `expand all` and `collapse all` button on the control bar.
The application must handle the callback and call the new `Graph` method `expandAll` or `collapseAll`. If the application is using a pipeline layout with generate spacer nodes and edges, it must recreate the model and relayout the view. 

An example of just how this is done can be found in: [PipelineGroupsDemo.collapseAllCallback](https://github.com/patternfly/react-topology/compare/main...jeff-phillips-18:react-topology:expand-collapse-all?expand=1#diff-c01eab00979c991ae559de70cd8e380f4f26471d0772521471d8c4efb0bb4559R86-R121)

Note that there are 2 new methods added to the `Graph` interface and an optional parameter `leafOnly` to the `getAllChildren` method on the `Node` interface. Any application that is current implementing these interfaces without extending the base implementation will need to adjust accordingly.

## Type of change
- [x] Feature

## Screen shots / Gifs for design review
![image](https://github.com/patternfly/react-topology/assets/11633780/ec21e9a7-9af3-455f-ab5c-b93c973d536e)


