### PR TITLE
chore(panIntoView): Add demo of the panIntoView functionality on node selection

### DIFF
--- a/packages/demo-app-ts/src/demos/topologyPackageDemo/TopologyPackage.tsx
+++ b/packages/demo-app-ts/src/demos/topologyPackageDemo/TopologyPackage.tsx
@@ -60,6 +60,26 @@ const TopologyViewComponent: React.FunctionComponent<TopologyViewComponentProps>
     });
 
     React.useEffect(() => {
+      let resizeTimeout: NodeJS.Timeout;
+
+      if (selectedIds[0]) {
+        const selectedNode = controller.getNodeById(selectedIds[0]);
+        if (selectedNode) {
+          // Use a timeout in order to allow the side panel to be shown and window size recomputed
+          resizeTimeout = setTimeout(() => {
+            controller.getGraph().panIntoView(selectedNode, { offset: 20, minimumVisible: 100 });
+            resizeTimeout = null;
+          }, 500);
+        }
+      }
+      return () => {
+        if (resizeTimeout) {
+          clearTimeout(resizeTimeout);
+        }
+      };
+    }, [selectedIds, controller]);
+
+    React.useEffect(() => {
       controller.addEventListener(GRAPH_POSITION_CHANGE_EVENT, graphPositionChangeListener);
       controller.addEventListener(GRAPH_LAYOUT_END_EVENT, layoutEndListener);
 


### PR DESCRIPTION
## What
Closes #207 

## Description
Adds functionality in the demo app `Topology Package Demo` for panning a node into view on selection when it would otherwise be covered by the side panel.

## Type of change
- [x] Other (please describe):
  Only adding a demo of existing functionality


