### PR TITLE
feat(pipelines): Add focus on newly expanded/collapsed groups

### DIFF
--- a/packages/module/src/elements/BaseGraph.ts
+++ b/packages/module/src/elements/BaseGraph.ts
@@ -239,16 +239,21 @@ export default class BaseGraph<E extends GraphModel = GraphModel, D = any>
     this.setPosition(new Point(x, y));
   }
 
-  fit(padding = 0): void {
+  fit(padding = 0, node?: Node): void {
     let rect: Rect | undefined;
-    this.getNodes().forEach((c) => {
-      const b = c.getBounds();
-      if (!rect) {
-        rect = b.clone();
-      } else {
-        rect.union(b);
-      }
-    });
+    if (node) {
+      rect = node.getBounds();
+    } else {
+      this.getNodes().forEach((c) => {
+        const b = c.getBounds();
+        if (!rect) {
+          rect = b.clone();
+        } else {
+          rect.union(b);
+        }
+      });
+    }
+
     if (!rect) {
       return;
     }
@@ -280,6 +285,22 @@ export default class BaseGraph<E extends GraphModel = GraphModel, D = any>
     this.setScale(scale);
     this.setPosition(new Point(tx, ty));
   }
+
+  centerInView = (nodeElement: Node): void => {
+    if (!nodeElement) {
+      return;
+    }
+    const { x: viewX, y: viewY, width: viewWidth, height: viewHeight } = this.getBounds();
+    const boundingBox = nodeElement.getBounds().clone().scale(this.scale).translate(viewX, viewY);
+    const { x, y, width, height } = boundingBox;
+
+    const newLocation = {
+      x: viewX - (x + width / 2) + viewWidth / 2,
+      y: viewY - (y + height / 2) + viewHeight / 2
+    };
+
+    this.setBounds(new Rect(newLocation.x, newLocation.y, viewWidth, viewHeight));
+  };
 
   panIntoView = (
     nodeElement: Node,

--- a/packages/module/src/pipelines/components/groups/DefaultTaskGroup.tsx
+++ b/packages/module/src/pipelines/components/groups/DefaultTaskGroup.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import { OnSelect, WithDndDragProps, ConnectDragSource, ConnectDropTarget } from '../../../behavior';
 import { ShapeProps } from '../../../components';
-import { Dimensions } from '../../../geom';
+import { Dimensions, Rect } from '../../../geom';
 import { GraphElement, LabelPosition, BadgeLocation, isNode, Node } from '../../../types';
 import { action } from '../../../mobx-exports';
 import { getEdgesFromNodes, getSpacerNodes } from '../../utils';
@@ -166,6 +166,33 @@ const DefaultTaskGroupInner: React.FunctionComponent<PipelinesDefaultGroupInnerP
           );
           controller.fromModel({ nodes, edges }, true);
           controller.getGraph().layout();
+        }
+      }
+
+      const graph = group.getGraph();
+      if (graph) {
+        if (!collapsed) {
+          graph.fit(80, group);
+        } else {
+          // Get the current graph required size
+          let rect: Rect | undefined;
+          graph.getNodes().forEach((c) => {
+            const b = c.getBounds();
+            if (!rect) {
+              rect = b.clone();
+            } else {
+              rect.union(b);
+            }
+          });
+
+          // If the required size is smaller, zoom in to fit the current graph
+          const graphBounds = graph.getBounds();
+          if (rect.width < graphBounds.width || rect.height < graphBounds.height) {
+            graph.fit(80);
+          }
+
+          // Center the graph on the group that was collapsed
+          graph.centerInView(group);
         }
       }
 

--- a/packages/module/src/types.ts
+++ b/packages/module/src/types.ts
@@ -284,7 +284,8 @@ export interface Graph<E extends GraphModel = GraphModel, D = any> extends Graph
   // viewport operations
   reset(): void;
   scaleBy(scale: number, location?: Point): void;
-  fit(padding?: number): void;
+  fit(padding?: number, node?: Node): void;
+  centerInView(nodeElement: Node): void;
   panIntoView(element: Node, options?: { offset?: number; minimumVisible?: number }): void;
   isNodeInView(element: Node, options?: { padding: number }): boolean;
 }


### PR DESCRIPTION
## What
Closes #206 

## Description
Adds a feature to `focus` on a group after it has been expanded or collapsed.

On expand the group will be shown in the view with the graph set to fit around the group so that the entire expansion can be viewed or be zoomed in on to emphasize the group.

On collapse, the view may be zoomed out so as not to show extra white space due to the collapsing of the group and the group will be centered in the view.

Note that a new method `centerInView` was added to the `Graph` interface and an optional parameter `node` to the `fit` method on the `Graph` interface. Any application that is current implementing these interfaces without extending the base implementation will need to adjust accordingly.

## Type of change
- [x] Feature


