### PR TITLE
fix(DefaultNode): Correctly scale the node's label on hover when zoomed iyt

### DIFF
--- a/packages/module/src/components/nodes/DefaultNode.tsx
+++ b/packages/module/src/components/nodes/DefaultNode.tsx
@@ -353,32 +353,40 @@ const DefaultNodeInner: React.FunctionComponent<DefaultNodeInnerProps> = observe
           )}
           {showLabel && (label || element.getLabel()) && (
             <Layer id={isHover ? TOP_LAYER : undefined}>
-              <g transform={`scale(${labelScale})`}>
-                <NodeLabel
-                  className={css(styles.topologyNodeLabel, labelClassName)}
-                  x={labelX}
-                  y={labelY * labelPositionScale}
-                  position={nodeLabelPosition}
-                  paddingX={8}
-                  paddingY={4}
-                  secondaryLabel={secondaryLabel}
-                  truncateLength={truncateLength}
-                  status={status}
-                  badge={badge}
-                  badgeColor={badgeColor}
-                  badgeTextColor={badgeTextColor}
-                  badgeBorderColor={badgeBorderColor}
-                  badgeClassName={badgeClassName}
-                  badgeLocation={badgeLocation}
-                  onContextMenu={onContextMenu}
-                  contextMenuOpen={contextMenuOpen}
-                  hover={isHover}
-                  labelIconClass={labelIconClass}
-                  labelIcon={labelIcon}
-                  labelIconPadding={labelIconPadding}
-                >
-                  {label || element.getLabel()}
-                </NodeLabel>
+              <g
+                transform={
+                  isHover
+                    ? `${scaleNode ? `translate(${translateX}, ${translateY})` : ''} scale(${nodeScale})`
+                    : undefined
+                }
+              >
+                <g transform={`scale(${labelScale})`}>
+                  <NodeLabel
+                    className={css(styles.topologyNodeLabel, labelClassName)}
+                    x={labelX}
+                    y={labelY * labelPositionScale}
+                    position={nodeLabelPosition}
+                    paddingX={8}
+                    paddingY={4}
+                    secondaryLabel={secondaryLabel}
+                    truncateLength={truncateLength}
+                    status={status}
+                    badge={badge}
+                    badgeColor={badgeColor}
+                    badgeTextColor={badgeTextColor}
+                    badgeBorderColor={badgeBorderColor}
+                    badgeClassName={badgeClassName}
+                    badgeLocation={badgeLocation}
+                    onContextMenu={onContextMenu}
+                    contextMenuOpen={contextMenuOpen}
+                    hover={isHover}
+                    labelIconClass={labelIconClass}
+                    labelIcon={labelIcon}
+                    labelIconPadding={labelIconPadding}
+                  >
+                    {label || element.getLabel()}
+                  </NodeLabel>
+                </g>
               </g>
             </Layer>
           )}


### PR DESCRIPTION
## What
Closes #211 

## Description
When hovering over a node when zoomed out, the label is brought to the top layer. This causes the transform used on the node to not have effect on the label. We need to set the transform to the same transform used by the node in order to get the same translation and scale.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review
![image](https://github.com/patternfly/react-topology/assets/11633780/625cca4d-eb71-4ebd-a7b8-17f55207da51)


