### PR TITLE
feat(group labels): Add ability to show group labels on hover

### DIFF
--- a/packages/demo-app-ts/src/demos/pipelineGroupsDemo/DemoTaskGroup.tsx
+++ b/packages/demo-app-ts/src/demos/pipelineGroupsDemo/DemoTaskGroup.tsx
@@ -12,10 +12,6 @@ import {
   EdgeCreationTypes,
   useHover,
   ScaleDetailsLevel,
-  DEFAULT_LAYER,
-  Layer,
-  TOP_LAYER,
-  GROUPS_LAYER,
   RunStatus
 } from '@patternfly/react-topology';
 import { DEFAULT_TASK_HEIGHT, GROUP_TASK_WIDTH } from './createDemoPipelineGroupsNodes';
@@ -38,29 +34,26 @@ const DemoTaskGroup: React.FunctionComponent<DemoTaskGroupProps> = ({ element, .
   if (!isNode(element)) {
     return null;
   }
-  const groupLayer = element.isCollapsed() ? DEFAULT_LAYER : GROUPS_LAYER;
 
   return (
-    <Layer id={detailsLevel !== ScaleDetailsLevel.high && hover ? TOP_LAYER : groupLayer}>
-      <g ref={hoverRef}>
-        <DefaultTaskGroup
-          labelPosition={verticalLayout ? LabelPosition.top : LabelPosition.bottom}
-          collapsible
-          collapsedWidth={GROUP_TASK_WIDTH}
-          collapsedHeight={DEFAULT_TASK_HEIGHT}
-          element={element as Node}
-          recreateLayoutOnCollapseChange
-          getEdgeCreationTypes={getEdgeCreationTypes}
-          scaleNode={hover && detailsLevel !== ScaleDetailsLevel.high}
-          showLabel={detailsLevel === ScaleDetailsLevel.high}
-          hideDetailsAtMedium
-          showStatusState
-          status={data.status}
-          hiddenDetailsShownStatuses={[RunStatus.Succeeded]}
-          {...rest}
-        />
-      </g>
-    </Layer>
+    <g id="group-hover-ref" ref={hoverRef}>
+      <DefaultTaskGroup
+        labelPosition={verticalLayout ? LabelPosition.top : LabelPosition.bottom}
+        collapsible
+        collapsedWidth={GROUP_TASK_WIDTH}
+        collapsedHeight={DEFAULT_TASK_HEIGHT}
+        element={element as Node}
+        recreateLayoutOnCollapseChange
+        getEdgeCreationTypes={getEdgeCreationTypes}
+        scaleNode={hover && detailsLevel !== ScaleDetailsLevel.high}
+        showLabelOnHover
+        hideDetailsAtMedium
+        showStatusState
+        status={data.status}
+        hiddenDetailsShownStatuses={[RunStatus.Succeeded]}
+        {...rest}
+      />
+    </g>
   );
 };
 

--- a/packages/demo-app-ts/src/demos/topologyPackageDemo/DemoGroup.tsx
+++ b/packages/demo-app-ts/src/demos/topologyPackageDemo/DemoGroup.tsx
@@ -58,6 +58,7 @@ const DemoGroup: React.FunctionComponent<DemoGroupProps> = ({ element, onContext
       collapsedHeight={DEFAULT_NODE_SIZE}
       showLabel={detailsLevel === ScaleDetailsLevel.high}
       hulledOutline={options.hulledOutline}
+      showLabelOnHover
     >
       {groupElement.isCollapsed() ? renderIcon() : null}
     </DefaultGroup>

--- a/packages/module/src/components/groups/DefaultGroup.tsx
+++ b/packages/module/src/components/groups/DefaultGroup.tsx
@@ -32,6 +32,8 @@ interface DefaultGroupProps {
   secondaryLabel?: string;
   /** Flag to show the label */
   showLabel?: boolean; // Defaults to true
+  /** Flag to show the label when hovering (effects expanded only) */
+  showLabelOnHover?: boolean;
   /** Position of the label, top or bottom. Defaults to element.getLabelPosition() or bottom */
   labelPosition?: LabelPosition;
   /** The maximum length of the label before truncation */

--- a/packages/module/src/pipelines/components/groups/DefaultTaskGroup.tsx
+++ b/packages/module/src/pipelines/components/groups/DefaultTaskGroup.tsx
@@ -46,6 +46,8 @@ export interface DefaultTaskGroupProps {
   scaleNode?: boolean;
   /** Flag to hide details at medium scale */
   hideDetailsAtMedium?: boolean;
+  /** Flag to show the label when hovering and details are hidden (effects expanded only) */
+  showLabelOnHover?: boolean;
   /** Flag if the user is hovering on the node */
   hover?: boolean;
   /** Label for the node. Defaults to element.getLabel() */


### PR DESCRIPTION
## What
Closes #213 

## Description
Adds a `showLabelOnHover` parameter to `DefaultGroup` and `DefaultTaskGroup` to show a group's label on hover. This is useful when an application hides details on zoom out but wants to see the label if the user hovers over the group.

## Type of change
- [x] Feature

## Screen shots / Gifs for design review
![image](https://github.com/patternfly/react-topology/assets/11633780/b3d3bdb9-a8e4-44ca-b49c-47dfff952990)


