### PR TITLE
feat(pipelines): support customStatusIcon

### DIFF
--- a/packages/demo-app-ts/src/demos/pipelinesDemo/DemoTaskNode.tsx
+++ b/packages/demo-app-ts/src/demos/pipelinesDemo/DemoTaskNode.tsx
@@ -82,6 +82,7 @@ const DemoTaskNode: React.FunctionComponent<DemoTaskNodeProps> = ({
           status={data.status}
           hideDetailsAtMedium
           leadIcon={getLeadIcon(data.taskJobType)}
+          customStatusIcon={data.customStatusIcon}
           taskIconClass={pipelineOptions.showIcons ? logos.get('icon-java') : undefined}
           taskIconTooltip={pipelineOptions.showIcons ? 'Environment' : undefined}
           badge={pipelineOptions.showBadges ? data.taskProgress : undefined}

--- a/packages/demo-app-ts/src/demos/pipelinesDemo/useDemoPipelineNodes.tsx
+++ b/packages/demo-app-ts/src/demos/pipelinesDemo/useDemoPipelineNodes.tsx
@@ -9,6 +9,7 @@ import {
   RunStatus,
   WhenStatus
 } from '@patternfly/react-topology';
+import { BanIcon } from '@patternfly/react-icons';
 
 export const NODE_PADDING_VERTICAL = 45;
 export const NODE_PADDING_HORIZONTAL = 15;
@@ -266,6 +267,36 @@ export const useDemoPipelineNodes = (
       iconTask2.y = GRAPH_MARGIN_TOP + row * ROW_HEIGHT;
     }
     tasks.push(iconTask2);
+
+    const iconTask3: PipelineNodeModel = {
+      id: `task-icon-3`,
+      type: DEFAULT_TASK_NODE_TYPE,
+      label: `Custom status icon task`,
+      width: DEFAULT_TASK_WIDTH + (showContextMenu ? 10 : 0) + (showBadges ? 40 : 0),
+      height: DEFAULT_TASK_HEIGHT,
+      style: {
+        padding: [NODE_PADDING_VERTICAL, NODE_PADDING_HORIZONTAL + (showIcons ? 25 : 0)]
+      },
+      runAfterTasks: [iconTask2.id]
+    };
+
+    iconTask3.data = {
+      status: RunStatus.Failed,
+      customStatusIcon: <BanIcon />,
+      taskProgress: '3/4',
+      taskType: 'java',
+      taskTopic: 'Environment',
+      columnGroup: (TASK_STATUSES.length % STATUS_PER_ROW) + 1
+      // taskJobType: 'link'
+    };
+
+    if (!layout) {
+      const row = Math.ceil((TASK_STATUSES.length + 1) / STATUS_PER_ROW) - 1;
+      const columnWidth = COLUMN_WIDTH + (showIcons ? 15 : 0) + (showBadges ? 32 : 0) + (showContextMenu ? 20 : 0);
+      iconTask2.x = (showIcons ? 28 : 0) + 2 * columnWidth;
+      iconTask2.y = GRAPH_MARGIN_TOP + row * ROW_HEIGHT;
+    }
+    tasks.push(iconTask3);
 
     return [...tasks, ...finallyNodes, finallyGroup];
   }, [layout, showBadges, showContextMenu, showGroups, showIcons]);

--- a/packages/demo-app-ts/src/demos/pipelinesDemo/useDemoPipelineNodes.tsx
+++ b/packages/demo-app-ts/src/demos/pipelinesDemo/useDemoPipelineNodes.tsx
@@ -287,14 +287,13 @@ export const useDemoPipelineNodes = (
       taskType: 'java',
       taskTopic: 'Environment',
       columnGroup: (TASK_STATUSES.length % STATUS_PER_ROW) + 1
-      // taskJobType: 'link'
     };
 
     if (!layout) {
       const row = Math.ceil((TASK_STATUSES.length + 1) / STATUS_PER_ROW) - 1;
       const columnWidth = COLUMN_WIDTH + (showIcons ? 15 : 0) + (showBadges ? 32 : 0) + (showContextMenu ? 20 : 0);
-      iconTask2.x = (showIcons ? 28 : 0) + 2 * columnWidth;
-      iconTask2.y = GRAPH_MARGIN_TOP + row * ROW_HEIGHT;
+      iconTask3.x = (showIcons ? 28 : 0) + 3 * columnWidth;
+      iconTask3.y = GRAPH_MARGIN_TOP + row * ROW_HEIGHT;
     }
     tasks.push(iconTask3);
 

--- a/packages/module/src/pipelines/components/nodes/TaskNode.tsx
+++ b/packages/module/src/pipelines/components/nodes/TaskNode.tsx
@@ -47,6 +47,8 @@ export interface TaskNodeProps {
   statusIconSize?: number;
   /** Flag indicating the status indicator */
   showStatusState?: boolean;
+  /** Custom icon to use as the status icon */
+  customStatusIcon?: React.ReactNode;
   /** Flag indicating the node should be scaled, best on hover of the node at lowest scale level */
   scaleNode?: boolean;
   /** Flag to hide details at medium scale */
@@ -138,6 +140,7 @@ const TaskNodeInner: React.FC<TaskNodeInnerProps> = observer(
     badgeTooltip,
     badgePopoverProps,
     badgePopoverParams,
+    customStatusIcon,
     nameLabelClass,
     taskIconClass,
     taskIcon,
@@ -296,6 +299,7 @@ const TaskNodeInner: React.FC<TaskNodeInnerProps> = observer(
       showStatusState,
       leadSize,
       leadIcon,
+      customStatusIcon,
       statusSize,
       badgeSize,
       badge,
@@ -437,7 +441,7 @@ const TaskNodeInner: React.FC<TaskNodeInnerProps> = observer(
                     (status === RunStatus.Running || status === RunStatus.InProgress) && styles.modifiers.spin
                   )}
                 >
-                  <StatusIcon status={status} />
+                  {customStatusIcon ?? <StatusIcon status={status} />}
                 </g>
               </g>
             ) : null}
@@ -501,7 +505,7 @@ const TaskNodeInner: React.FC<TaskNodeInnerProps> = observer(
                   (status === RunStatus.Running || status === RunStatus.InProgress) && styles.modifiers.spin
                 )}
               >
-                <StatusIcon status={status} />
+                {customStatusIcon ?? <StatusIcon status={status} />}
               </g>
             </g>
           )}


### PR DESCRIPTION
## What
Closes #208

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds a new customStatusIcon prop to allow for a persisting icon with the correct status icon styling when a node is hovered or zoomed out.  

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review

Default node view:
<img width="238" alt="Screenshot 2024-06-03 at 3 29 57 PM" src="https://github.com/patternfly/react-topology/assets/32821331/d730e6c7-47d5-48e3-8aaf-453d3f36c2d8">

Low details level/ zoomed out view:
<img width="58" alt="Screenshot 2024-06-03 at 3 30 02 PM" src="https://github.com/patternfly/react-topology/assets/32821331/fd13e0b8-5acc-46b2-8543-1e1c07bdb7b6">

