### PR TITLE
feat(graph): Add selection based zoom

### DIFF
--- a/packages/demo-app-ts/src/demos/topologyPackageDemo/AreaDragHint.css
+++ b/packages/demo-app-ts/src/demos/topologyPackageDemo/AreaDragHint.css
@@ -1,0 +1,43 @@
+.area-drag-hint__hint-container {
+    justify-content: center;
+    display: flex;
+    pointer-events: none;
+    position: absolute;
+    top: var(--pf-v5-global--spacer--sm);
+    left: 0;
+    right: 0;
+    z-index: 99;
+}
+.area-drag-hint__hint-background {
+    background-color: var(--pf-v5-global--BackgroundColor--100);
+    border: 1px solid var(--pf-v5-global--BorderColor--light-100);
+    border-radius: 8px;
+    padding: var(--pf-v5-global--spacer--xs) var(--pf-v5-global--spacer--sm);
+    pointer-events: none;
+}
+
+.area-drag-hint {
+    align-items: center;
+    display: flex;
+}
+.area-drag-hint__icon {
+    color: var(--pf-v5-global--palette--blue-300);
+}
+.area-drag-hint__text {
+    margin-left: var(--pf-v5-global--spacer--sm);
+}
+.area-drag-hint-shortcut__cell {
+    padding-left: var(--pf-v5-global--spacer--sm);
+}
+
+.area-drag-hint-shortcut__command:not(:last-child):after {
+    content: ' + ';
+}
+
+.area-drag-hint-shortcut__kbd {
+    border: var(--pf-v5-global--BorderWidth--sm) solid var(--pf-v5-global--BorderColor--100);
+    border-radius: 3px;
+    color: var(--pf-v5-global--Color--200);
+    font-size: var(--pf-v5-global--FontSize--sm);
+    padding: 1px 3px;
+}

--- a/packages/demo-app-ts/src/demos/topologyPackageDemo/AreaDragHint.tsx
+++ b/packages/demo-app-ts/src/demos/topologyPackageDemo/AreaDragHint.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { InfoCircleIcon, MouseIcon } from '@patternfly/react-icons';
+
+import './AreaDragHint.css';
+
+const AreaDragHint: React.FC = () => {
+  return (
+    <div className="area-drag-hint__hint-container">
+      <div className="area-drag-hint__hint-background">
+        <div className="area-drag-hint">
+          <InfoCircleIcon className="area-drag-hint__icon" />
+          <span className="area-drag-hint__text">
+            <table>
+              <tbody>
+                <tr>
+                  <td className="area-drag-hint-shortcut__cell">
+                    <span className="area-drag-hint-shortcut__command">
+                      <kbd className="area-drag-hint-shortcut__kbd">Shift</kbd>
+                    </span>
+                    <span className="area-drag-hint-shortcut__command">
+                      <kbd className="area-drag-hint-shortcut__kbd">
+                        <MouseIcon /> Drag
+                      </kbd>
+                    </span>
+                  </td>
+                  <td className="area-drag-hint-shortcut__cell">Select nodes in area</td>
+                </tr>
+                <tr>
+                  <td className="area-drag-hint-shortcut__cell">
+                    <span className="area-drag-hint-shortcut__command">
+                      <kbd className="area-drag-hint-shortcut__kbd">Ctrl</kbd>
+                    </span>
+                    <span className="area-drag-hint-shortcut__command">
+                      <kbd className="area-drag-hint-shortcut__kbd">
+                        <MouseIcon /> Drag
+                      </kbd>
+                    </span>
+                  </td>
+                  <td className="area-drag-hint-shortcut__cell">Zoom to selected area</td>
+                </tr>
+              </tbody>
+            </table>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AreaDragHint;

--- a/packages/demo-app-ts/src/demos/topologyPackageDemo/demoComponentFactory.tsx
+++ b/packages/demo-app-ts/src/demos/topologyPackageDemo/demoComponentFactory.tsx
@@ -10,8 +10,9 @@ import {
   ModelKind,
   DragObjectWithType,
   Node,
-  withPanZoom,
   GraphComponent,
+  withPanZoom,
+  withAreaSelection,
   withCreateConnector,
   Graph,
   isNode,
@@ -60,7 +61,9 @@ const demoComponentFactory: ComponentFactory = (
   type: string
 ): React.ComponentType<{ element: GraphElement }> | undefined => {
   if (kind === ModelKind.graph) {
-    return withDndDrop(graphDropTargetSpec([NODE_DRAG_TYPE]))(withPanZoom()(GraphComponent));
+    return withDndDrop(graphDropTargetSpec([NODE_DRAG_TYPE]))(
+      withPanZoom()(withAreaSelection(['ctrlKey', 'shiftKey'])(GraphComponent))
+    );
   }
   switch (type) {
     case 'node':

--- a/packages/module/src/behavior/index.ts
+++ b/packages/module/src/behavior/index.ts
@@ -6,6 +6,7 @@ export * from './useDndDrop';
 export * from './useDndManager';
 export * from './useDragNode';
 export * from './usePanZoom';
+export * from './useAreaSelection';
 export * from './useReconnect';
 export * from './useSelection';
 export * from './usePolygonAnchor';

--- a/packages/module/src/behavior/useAreaSelection.tsx
+++ b/packages/module/src/behavior/useAreaSelection.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import * as d3 from 'd3';
+import { observer } from 'mobx-react';
+import { action } from 'mobx';
+import ElementContext from '../utils/ElementContext';
+import useCallbackRef from '../utils/useCallbackRef';
+import { Graph, GRAPH_AREA_DRAGGING_EVENT, GRAPH_AREA_SELECTED_EVENT, isGraph, ModifierKey } from '../types';
+import Point from '../geom/Point';
+
+export type AreaSelectionRef = (node: SVGGElement | null) => void;
+
+// Used to send events prevented by d3.zoom to the document allowing modals, dropdowns, etc, to close
+const propagateAreaSelectionMouseEvent = (e: Event): void => {
+  document.dispatchEvent(new MouseEvent(e.type, e));
+};
+
+export const useAreaSelection = (modifiers: ModifierKey[] = ['ctrlKey']): WithAreaSelectionProps => {
+  const element = React.useContext(ElementContext);
+  const [draggingState, setDraggingState] = React.useState<Omit<WithAreaSelectionProps, 'areaSelectionRef'>>({});
+
+  if (!isGraph(element)) {
+    throw new Error('useAreaSelection must be used within the scope of a Graph');
+  }
+  const elementRef = React.useRef<Graph>(element);
+  elementRef.current = element;
+
+  const areaSelectionRef = useCallbackRef<AreaSelectionRef>((node: SVGGElement | null) => {
+    if (node) {
+      // TODO fix any type
+      const $svg = d3.select(node.ownerSVGElement) as any;
+      if (node && node.ownerSVGElement) {
+        node.ownerSVGElement.addEventListener('mousedown', propagateAreaSelectionMouseEvent);
+        node.ownerSVGElement.addEventListener('click', propagateAreaSelectionMouseEvent);
+      }
+      const drag = d3
+        .drag()
+        .on(
+          'start',
+          action((event: d3.D3DragEvent<Element, any, any>) => {
+            const { offsetX, offsetY } =
+              event.sourceEvent instanceof MouseEvent ? event.sourceEvent : { offsetX: 0, offsetY: 0 };
+            const { width: maxX, height: maxY } = elementRef.current.getDimensions();
+
+            const startPoint = new Point(Math.min(Math.max(offsetX, 0), maxX), Math.min(Math.max(offsetY, 0), maxY));
+            const modifier = modifiers.find((m) => event.sourceEvent[m]);
+
+            setDraggingState({
+              modifier,
+              isAreaSelectDragging: true,
+              areaSelectDragStart: startPoint,
+              areaSelectDragEnd: startPoint
+            });
+            elementRef.current
+              .getController()
+              .fireEvent(GRAPH_AREA_DRAGGING_EVENT, { graph: elementRef.current, isDragging: true });
+          })
+        )
+        .on(
+          'drag',
+          action((event: d3.D3DragEvent<Element, any, any>) => {
+            const { offsetX, offsetY } =
+              event.sourceEvent instanceof MouseEvent ? event.sourceEvent : { offsetX: 0, offsetY: 0 };
+            const { width: maxX, height: maxY } = elementRef.current.getDimensions();
+            setDraggingState((prev) => ({
+              ...prev,
+              areaSelectDragEnd: new Point(Math.min(Math.max(offsetX, 0), maxX), Math.min(Math.max(offsetY, 0), maxY))
+            }));
+          })
+        )
+        .on(
+          'end',
+          action(() => {
+            setDraggingState((prev) => {
+              elementRef.current.getController().fireEvent(GRAPH_AREA_SELECTED_EVENT, {
+                graph: elementRef.current,
+                modifier: prev.modifier,
+                startPoint: prev.areaSelectDragStart,
+                endPoint: prev.areaSelectDragEnd
+              });
+              return { isAreaSelectDragging: false };
+            });
+            elementRef.current
+              .getController()
+              .fireEvent(GRAPH_AREA_DRAGGING_EVENT, { graph: elementRef.current, isDragging: false });
+          })
+        )
+        .filter((event: React.MouseEvent) => modifiers.find((m) => event[m]) && !event.button);
+      drag($svg);
+    }
+
+    return () => {
+      if (node) {
+        // remove all drag listeners
+        d3.select(node.ownerSVGElement).on('.drag', null);
+        if (node.ownerSVGElement) {
+          node.ownerSVGElement.removeEventListener('mousedown', propagateAreaSelectionMouseEvent);
+          node.ownerSVGElement.removeEventListener('click', propagateAreaSelectionMouseEvent);
+        }
+      }
+    };
+  });
+  return { areaSelectionRef, ...draggingState };
+};
+export interface WithAreaSelectionProps {
+  areaSelectionRef?: AreaSelectionRef;
+  modifier?: ModifierKey;
+  isAreaSelectDragging?: boolean;
+  areaSelectDragStart?: Point;
+  areaSelectDragEnd?: Point;
+}
+
+export const withAreaSelection =
+  (modifier: ModifierKey[] = ['ctrlKey']) =>
+  <P extends WithAreaSelectionProps>(WrappedComponent: React.ComponentType<P>) => {
+    const Component: React.FunctionComponent<Omit<P, keyof WithAreaSelectionProps>> = (props) => {
+      const areaSelectionProps = useAreaSelection(modifier);
+      return <WrappedComponent {...(props as any)} {...areaSelectionProps} />;
+    };
+    Component.displayName = `withAreaSelection(${WrappedComponent.displayName || WrappedComponent.name})`;
+    return observer(Component);
+  };

--- a/packages/module/src/css/topology-components.css
+++ b/packages/module/src/css/topology-components.css
@@ -161,6 +161,9 @@
   --pf-topology-default-create-connector--m-hover--line--Stroke: var(--pf-v5-global--Color--100);
   --pf-topology-default-create-connector--m-hover--arrow--Fill: var(--pf-v5-global--Color--100);
   --pf-topology-default-create-connector--m-hover--arrow--Stroke: var(--pf-v5-global--Color--100);
+
+  --pf-topology__area-select-rect--Fill: var(--pf-v5-global--palette--black-500);
+  --pf-topology__area-select-rect--Opacity: 0.4;
 }
 
 /* DARK THEME OVERRIDES */
@@ -245,6 +248,7 @@
   --pf-topology__edge__tag__text--Fill: var(--pf-v5-global--palette--black-900);
   --pf-topology__edge__tag__text--Stroke: var(--pf-v5-global--palette--black-900);
 
+  --pf-topology__area-select-rect--Fill: var(--pf-v5-global--palette--black-300);
 }
 
 .pf-topology-visualization-surface {
@@ -861,3 +865,7 @@
   fill: var(--pf-topology__create-connector-color--Fill);
 }
 
+.pf-topology-area-select-rect {
+  fill: var(--pf-topology__area-select-rect--Fill);
+  opacity: var(--pf-topology__area-select-rect--Opacity);
+}

--- a/packages/module/src/types.ts
+++ b/packages/module/src/types.ts
@@ -287,6 +287,8 @@ export interface Graph<E extends GraphModel = GraphModel, D = any> extends Graph
   fit(padding?: number, node?: Node): void;
   centerInView(nodeElement: Node): void;
   panIntoView(element: Node, options?: { offset?: number; minimumVisible?: number }): void;
+  zoomToSelection(startPoint: Point, endPoint: Point): void;
+  nodesInSelection(startPoint: Point, endPoint: Point): Node[];
   isNodeInView(element: Node, options?: { padding: number }): boolean;
   expandAll(): void;
   collapseAll(): void;
@@ -356,6 +358,13 @@ export type NodeCollapseChangeEventListener = EventListener<[{ node: Node }]>;
 
 export type GraphLayoutEndEventListener = EventListener<[{ graph: Graph }]>;
 
+export type ModifierKey = 'ctrlKey' | 'shiftKey' | 'altKey';
+
+export type GraphAreaDraggingEvent = EventListener<[{ graph: Graph; isDragging: boolean }]>;
+export type GraphAreaSelectedEventListener = EventListener<
+  [{ graph: Graph; modifier: ModifierKey; startPoint: Point; endPoint: Point }]
+>;
+
 export const ADD_CHILD_EVENT = 'element-add-child';
 export const ELEMENT_VISIBILITY_CHANGE_EVENT = 'element-visibility-change';
 export const REMOVE_CHILD_EVENT = 'element-remove-child';
@@ -363,3 +372,5 @@ export const NODE_COLLAPSE_CHANGE_EVENT = 'node-collapse-change';
 export const NODE_POSITIONED_EVENT = 'node-positioned';
 export const GRAPH_LAYOUT_END_EVENT = 'graph-layout-end';
 export const GRAPH_POSITION_CHANGE_EVENT = 'graph-position-change';
+export const GRAPH_AREA_DRAGGING_EVENT = 'graph-area-dragging';
+export const GRAPH_AREA_SELECTED_EVENT = 'graph-area-selected';


### PR DESCRIPTION
## What
Closes #222 

## Description
Adds the ability to drag an area on the graph.
Added events for:
- GRAPH_AREA_DRAGGING_EVENT - When user is dragging an area on the graph
- GRAPH_AREA_SELECTED_EVENT - When the user completed the selection of an area

Adds a hook to allow area selection via `withAreaSelection`. This takes key modifiers that can be handled separately so applications can do different things based on the shift key, cntrl key, etc.

Adds two methods to the `Graph` element:
- zoomToSelection : pass it the values from the `GRAPH_AREA_SELECTED_EVENT` to zoom to that area
- nodesInSelection : pass it the values from the `GRAPH_AREA_SELECTED_EVENT` to get all nodes in that area

The Topology Package demo is updated to add both shift and cntrl drag and to zoom for cntrl and select nodes for shift. Also handles the `GRAPH_AREA_DRAGGING_EVENT` to show a hint to users on how to perform these actions.

## Type of change
- [x] Feature

## Screen shots / Gifs for design review

![TopologyAreaSelect](https://github.com/user-attachments/assets/270e1553-ad13-4480-bf41-124269624f78)

