### PR TITLE
Feat(context menu): Add the hideContextMenuKebab option to groups

### DIFF
--- a/packages/demo-app-ts/src/demos/topologyPackageDemo/DemoGroup.tsx
+++ b/packages/demo-app-ts/src/demos/topologyPackageDemo/DemoGroup.tsx
@@ -51,7 +51,8 @@ const DemoGroup: React.FunctionComponent<DemoGroupProps> = ({ element, onContext
   return (
     <DefaultGroup
       {...rest}
-      onContextMenu={data.showContextMenu ? onContextMenu : undefined}
+      onContextMenu={options.contextMenus ? onContextMenu : undefined}
+      hideContextMenuKebab={options.hideKebabMenu}
       element={element}
       collapsible
       collapsedWidth={DEFAULT_NODE_SIZE}

--- a/packages/module/src/components/groups/DefaultGroup.tsx
+++ b/packages/module/src/components/groups/DefaultGroup.tsx
@@ -82,6 +82,8 @@ interface DefaultGroupProps {
   onContextMenu?: (e: React.MouseEvent) => void;
   /** Flag indicating that the context menu for the node is currently open  */
   contextMenuOpen?: boolean;
+  /** Hide context menu kebab for the group  */
+  hideContextMenuKebab?: boolean;
   /** Flag indicating whether to use hull layout or rect layout for expanded groups. Defaults to hull (true) */
   hulledOutline?: boolean;
 }

--- a/packages/module/src/components/groups/DefaultGroupCollapsed.tsx
+++ b/packages/module/src/components/groups/DefaultGroupCollapsed.tsx
@@ -32,6 +32,7 @@ type DefaultGroupCollapsedProps = {
   label?: string; // Defaults to element.getLabel()
   secondaryLabel?: string;
   showLabel?: boolean; // Defaults to true
+  hideContextMenuKebab?: boolean;
   labelPosition?: LabelPosition; // Defaults to bottom
   truncateLength?: number; // Defaults to 13
   labelIconClass?: string; // Icon to show in label
@@ -72,6 +73,7 @@ const DefaultGroupCollapsed: React.FunctionComponent<DefaultGroupCollapsedProps>
   dropTarget,
   onContextMenu,
   contextMenuOpen,
+  hideContextMenuKebab,
   dragging,
   labelPosition,
   badge,
@@ -174,6 +176,7 @@ const DefaultGroupCollapsed: React.FunctionComponent<DefaultGroupCollapsedProps>
           labelIconPadding={labelIconPadding}
           onContextMenu={onContextMenu}
           contextMenuOpen={contextMenuOpen}
+          hideContextMenuKebab={hideContextMenuKebab}
           hover={isHover || labelHover}
           actionIcon={collapsible ? <ExpandIcon /> : undefined}
           onActionIconClick={() => onCollapseChange(element, false)}

--- a/packages/module/src/components/groups/DefaultGroupExpanded.tsx
+++ b/packages/module/src/components/groups/DefaultGroupExpanded.tsx
@@ -32,6 +32,7 @@ type DefaultGroupExpandedProps = {
   secondaryLabel?: string;
   showLabel?: boolean; // Defaults to true
   showLabelOnHover?: boolean;
+  hideContextMenuKebab?: boolean;
   truncateLength?: number; // Defaults to 13
   badge?: string;
   badgeColor?: string;
@@ -128,6 +129,7 @@ const DefaultGroupExpanded: React.FunctionComponent<DefaultGroupExpandedProps> =
   dropTarget,
   onContextMenu,
   contextMenuOpen,
+  hideContextMenuKebab,
   dragging,
   dragNodeRef,
   badge,
@@ -270,6 +272,7 @@ const DefaultGroupExpanded: React.FunctionComponent<DefaultGroupExpandedProps> =
           labelIconPadding={labelIconPadding}
           onContextMenu={onContextMenu}
           contextMenuOpen={contextMenuOpen}
+          hideContextMenuKebab={hideContextMenuKebab}
           hover={isHover || labelHover}
           actionIcon={collapsible ? <CollapseIcon /> : undefined}
           onActionIconClick={() => onCollapseChange(element, true)}


### PR DESCRIPTION
## What
Closes #254 

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds prop hideContextMenuKebab to toggle context menu via Shift + Right Click only. cc @ferhoyos

To test:

In StyleGroup.tsx, add `hideContextMenuKebab` as a prop of the `DefaultGroup` component. In the demo app, go to Styles -> Groups -> Collapsible Groups. Verify the menu kebab is hidden and can be toggled with Shift + Right click.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review
Before:
<img width="800" alt="Screenshot 2024-12-03 at 4 02 40 PM" src="https://github.com/user-attachments/assets/6f24539f-121b-42b3-9e02-270026d94f81">

After:
<img width="800" alt="Screenshot 2024-12-03 at 4 02 25 PM" src="https://github.com/user-attachments/assets/ed03f204-b59d-426f-8309-f7377f1a1126">

