### PR TITLE
feat(groups): Add the labelClassName prop to groups

### DIFF
--- a/packages/module/src/components/groups/DefaultGroup.tsx
+++ b/packages/module/src/components/groups/DefaultGroup.tsx
@@ -32,6 +32,8 @@ interface DefaultGroupProps {
   secondaryLabel?: string;
   /** Flag to show the label */
   showLabel?: boolean; // Defaults to true
+  /** Additional classes to add to the label */
+  labelClassName?: string;
   /** Flag to show the label when hovering (effects expanded only) */
   showLabelOnHover?: boolean;
   /** Position of the label, top or bottom. Defaults to element.getLabelPosition() or bottom */

--- a/packages/module/src/components/groups/DefaultGroupCollapsed.tsx
+++ b/packages/module/src/components/groups/DefaultGroupCollapsed.tsx
@@ -44,6 +44,7 @@ type DefaultGroupCollapsedProps = {
   badgeBorderColor?: string;
   badgeClassName?: string;
   badgeLocation?: BadgeLocation;
+  labelClassName?: string;
 } & CollapsibleGroupProps &
   WithDragNodeProps &
   WithSelectionProps &
@@ -84,7 +85,8 @@ const DefaultGroupCollapsed: React.FunctionComponent<DefaultGroupCollapsedProps>
   badgeLocation,
   labelIconClass,
   labelIcon,
-  labelIconPadding
+  labelIconPadding,
+  labelClassName
 }) => {
   const [hovered, hoverRef] = useHover();
   const [labelHover, labelHoverRef] = useHover();
@@ -156,7 +158,7 @@ const DefaultGroupCollapsed: React.FunctionComponent<DefaultGroupCollapsedProps>
       )}
       {showLabel && (
         <NodeLabel
-          className={styles.topologyGroupLabel}
+          className={css(styles.topologyGroupLabel, labelClassName)}
           x={collapsedWidth / 2}
           y={labelPosition === LabelPosition.top ? collapsedHeight / 2 - collapsedHeight : collapsedHeight + 6}
           paddingX={8}

--- a/packages/module/src/components/groups/DefaultGroupExpanded.tsx
+++ b/packages/module/src/components/groups/DefaultGroupExpanded.tsx
@@ -40,6 +40,7 @@ type DefaultGroupExpandedProps = {
   badgeBorderColor?: string;
   badgeClassName?: string;
   badgeLocation?: BadgeLocation;
+  labelClassName?: string;
   labelIconClass?: string; // Icon to show in label
   labelIcon?: string;
   labelPosition?: LabelPosition;
@@ -138,6 +139,7 @@ const DefaultGroupExpanded: React.FunctionComponent<DefaultGroupExpandedProps> =
   badgeBorderColor,
   badgeClassName,
   badgeLocation,
+  labelClassName,
   labelIconClass,
   labelIcon,
   labelPosition,
@@ -252,7 +254,7 @@ const DefaultGroupExpanded: React.FunctionComponent<DefaultGroupExpandedProps> =
     (showLabel || (showLabelOnHover && isHover)) && (label || element.getLabel()) ? (
       <g ref={labelHoverRef} transform={isHover ? `scale(${labelScale})` : undefined}>
         <NodeLabel
-          className={styles.topologyGroupLabel}
+          className={css(styles.topologyGroupLabel, labelClassName)}
           x={startX * labelPositionScale}
           y={startY * labelPositionScale}
           paddingX={8}


### PR DESCRIPTION
## What
Closes #255

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
To test, add `labelClassName="test"` to the <DefaultGroup> component in `DemoGroup.tsx`. Verify the custom class is visible in Topology Package via the demo app. 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review
<img width="500" alt="Screenshot 2024-12-05 at 3 30 27 PM" src="https://github.com/user-attachments/assets/b859b070-ab77-4682-a423-3771be4f41d7">
<img width="550" alt="Screenshot 2024-12-05 at 3 30 51 PM" src="https://github.com/user-attachments/assets/64941be5-6277-4c86-8f58-d121c251644f">


