### PR TITLE
Update demo readme and main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,38 +202,8 @@ export const TopologyBaselineDemo = React.memo(() => {
 
 To help you better understand and visualize the different Topology components, we have created an interactive demo, [which is contained here.](https://github.com/patternfly/react-topology/tree/main/packages/demo-app-ts)
 
-Continue reading for instructions on how to build and run the demo app. 
+See the instructions to install and run the demo app, here: [Demo README.md](packages/demo-app-ts/README.md)
 
-### Prerequisites
-
-In order to run the demo app, you need to make sure the following prerequisites are met. 
-
-1. Make sure that you have yarn installed, as outlined in [the general Topology prerequisites.](#prerequisites) 
-1. If you haven’t already, [fork the Topology project.](https://github.com/patternfly/react-topology)
-
-### Running the demo app
-
-Once you’ve set up the prerequisites, you can follow these steps to run the docs workspace or the demo app on your local machine
-
-1. In a terminal, type the following commands to start the docs workspace:
-
-```
-yarn install
-yarn start
-```
-
-2. In a terminal, type the following commands to navigate to demo-app-ts and launch the demo app:
-
-```
-cd packages/demo-app-ts
-yarn start:demo-app:hot
-```
-
-3. You will receive a message confirming that the app is running. To view the locally running workspace, visit http://localhost:8008/.
-
-4. Explore the demo app in your browser:
-
-![Demo app landing page.](packages/module/patternfly-docs/content/examples/img/topology-demo-app.png)
 
 ## Need help? 
 If you find a bug, have a request, or have any questions about Topology that aren't answered in our documentation, please [reach out to us on Slack.](https://patternfly.slack.com/archives/CK7URGJ2W)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To use Topology, you will need to have both [Node Active LTS](https://github.com
 
 ## Installing Topology
 
-Once you have all of the prequisites, you can install the Topology package with Yarn or npm:
+Once you have all of the prerequisites, you can install the Topology package with Yarn or npm:
 
 1. Using Yarn:
 

--- a/packages/demo-app-ts/README.md
+++ b/packages/demo-app-ts/README.md
@@ -43,7 +43,7 @@ yarn start:demo-app:hot
 <i> [webpack-dev-server] Loopback: http://localhost:3000/
 ```
 
-4. Explore the demo app in your browser:
+4. Explore the demo app in [your browser](http://localhost:3000/)
 
 ![Demo app landing page.](../../packages/module/patternfly-docs/content/examples/img/topology-demo-app.png)
 

--- a/packages/demo-app-ts/README.md
+++ b/packages/demo-app-ts/README.md
@@ -1,3 +1,4 @@
+[the general Topology prerequisites]: ../../README.md#prerequisites
 # Topology demo app
 
 To help you better understand and visualize the different Topology components, we have created an interactive demo, [which is contained here.](https://github.com/patternfly/react-topology/tree/main/packages/demo-app-ts)
@@ -8,8 +9,8 @@ Continue reading for instructions on how to build and run the demo app.
 
 In order to run the demo app, you need to make sure the following prerequisites are met. 
 
-1. Make sure that you have yarn installed, as outlined in [the general Topology prerequisites.](#prerequisites) 
-1. Make sure that you have the PatternFly React library installed. [Follow these instructions if you need to install this package.](https://github.com/patternfly/patternfly-react?tab=readme-ov-file#install-and-configure-patternfly-react)
+1. Make sure that you have yarn installed, as outlined in [the general Topology prerequisites].
+1. Make sure that you have the PatternFly React library installed. [Follow these instructions if you  need to install this package.](https://github.com/patternfly/patternfly-react?tab=readme-ov-file#install-and-configure-patternfly-react)
 1. If you haven’t already, clone [the Topology project](https://github.com/patternfly/react-topology) and navigate to your local directory:
 
 ``` 
@@ -21,14 +22,14 @@ cd react-topology
 
 Once you’ve set up the prerequisites, you can follow these steps to run the demo app on your local machine
 
-1. In a terminal, type the following commands to start the docs workspace:
+1. In a terminal, type the following commands to start the `react topology docs workspace`:
 
 ```
 yarn install
 yarn start
 ```
 
-2. In a separate terminal window, type the following commands to navigate to demo-app-ts and launch the demo app:
+2. In a **separate** terminal window, type the following commands to navigate to `demo-app-ts` and launch the demo app:
 
 ```
 cd packages/demo-app-ts
@@ -44,7 +45,7 @@ yarn start:demo-app:hot
 
 4. Explore the demo app in your browser:
 
-![Demo app landing page.](packages/module/patternfly-docs/content/examples/img/topology-demo-app.png)
+![Demo app landing page.](../../packages/module/patternfly-docs/content/examples/img/topology-demo-app.png)
 
 ## Need help? 
 If you find a bug, have a request, or have any questions about Topology that aren't answered in our documentation, please [reach out to us on Slack.](https://patternfly.slack.com/archives/CK7URGJ2W)

--- a/packages/module/release.config.js
+++ b/packages/module/release.config.js
@@ -1,8 +1,5 @@
 module.exports = {
-  branches: [
-    'do-not-delete',
-    { name: 'main', channel: 'prerelease', prerelease: 'prerelease' },
-  ],
+  branches: ['do-not-delete', { name: 'main', channel: 'prerelease', prerelease: 'prerelease' }],
   analyzeCommits: {
     preset: 'angular'
   },


### PR DESCRIPTION
## Description
Onboarding to the project, and trying out the awesome demo. Wanted to make a few small improvements to the docs.

## Work left

- [x] Reconcile the main demo instructions, vs. the `packages/demo-app-ts/README.md`, and use a link to the correct instructions instead of having 2 sets. 

## Type of change
- [x] Documentation content changes

## Screen shots / Gifs for design review
See the GitHub UI for the rich markdown previews; 
https://github.com/patternfly/react-topology/blob/57765372d242b57321e6ad220ab72d9e7c42b1cb/packages/demo-app-ts/README.md


This PR should also fix the demo image being a 404:

> <img width="371" alt="demo module screenshot is not rendering, due to a relative path bug." src="https://github.com/user-attachments/assets/2b1ac3aa-31ae-4870-8dd8-6812ac35d7b5"/>


