### PR TITLE
fix(ContextMenu): Update context menu placement on items change

### DIFF
--- a/packages/module/src/components/contextmenu/ContextMenu.tsx
+++ b/packages/module/src/components/contextmenu/ContextMenu.tsx
@@ -25,6 +25,14 @@ const ContextMenu: React.FunctionComponent<ContextMenuProps> = ({
     onRequestClose ? onRequestClose() : setOpen(false);
   }, [onRequestClose]);
 
+  React.useEffect(() => {
+    if (isOpen) {
+      setOpen(false);
+      requestAnimationFrame(() => setOpen(true));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [children]);
+
   return (
     <Popper {...other} closeOnEsc closeOnOutsideClick open={isOpen} onRequestClose={handleOnRequestClose}>
       <Dropdown


### PR DESCRIPTION
## What
Closes #238 

## Description
Adds an effect to force a recompute of the context menu position when the context menu items change.


## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review

![Kapture 2025-02-25 at 14 41 15](https://github.com/user-attachments/assets/14bd10fe-018a-48fc-aadb-29b42e9bf57a)

