### PR TITLE
feat: Enable DefaultEdge as drop target

### DIFF
--- a/packages/demo-app-ts/src/demos/DragDrop.tsx
+++ b/packages/demo-app-ts/src/demos/DragDrop.tsx
@@ -14,7 +14,10 @@ import {
   useModel,
   useComponentFactory,
   ComponentFactory,
-  GraphElement
+  GraphElement,
+  DefaultEdge,
+  Edge,
+  isEdge
 } from '@patternfly/react-topology';
 import defaultComponentFactory from '../components/defaultComponentFactory';
 import DemoDefaultNode from '../components/DemoDefaultNode';
@@ -254,6 +257,166 @@ export const DndShiftRegroup = withTopologySetup(() => {
   return null;
 });
 
+export const DndEdges = withTopologySetup(() => {
+  useComponentFactory(defaultComponentFactory);
+  // support pan zoom and drag
+  useComponentFactory(
+    React.useCallback<ComponentFactory>((kind, type) => {
+      if (kind === ModelKind.graph) {
+        return withPanZoom()(GraphComponent);
+      }
+      if (type === 'group-drop') {
+        return withDndDrop<
+          GraphElement,
+          any,
+          { droppable?: boolean; hover?: boolean; canDrop?: boolean },
+          ElementProps
+        >({
+          accept: 'test',
+          canDrop: (item, monitor, props) => !!props && (item as Node).getParent() !== props.element,
+          collect: (monitor) => ({
+            droppable: monitor.isDragging(),
+            hover: monitor.isOver(),
+            canDrop: monitor.canDrop()
+          })
+        })(GroupHull);
+      }
+      if (type === 'node-drag') {
+        return withDndDrag<DragObjectWithType, Node, {}, ElementProps>({
+          item: { type: 'test' },
+          begin: (monitor, props) => {
+            props.element.raise();
+            return props.element;
+          },
+          drag: (event, monitor, props) => {
+            const nodeElement = props.element as Node;
+            nodeElement.setPosition(nodeElement.getPosition().clone().translate(event.dx, event.dy));
+          },
+          end: (dropResult, monitor, props) => {
+            if (monitor.didDrop() && dropResult && props) {
+              if (isEdge(dropResult)) {
+                const droppedEdge = dropResult as Edge;
+                const newEdge1 = {
+                  type: droppedEdge.getType(),
+                  id: `${droppedEdge.getSource().getId()}-${props.element.getId()}`,
+                  source: droppedEdge.getSource().getId(),
+                  target: props.element.getId()
+                };
+                const newEdge2 = {
+                  type: droppedEdge.getType(),
+                  id: `${props.element.getId()}-${droppedEdge.getTarget().getId()}`,
+                  source: props.element.getId(),
+                  target: droppedEdge.getTarget().getId()
+                };
+                const model = droppedEdge.getController().toModel();
+                const updateModel: Model = { edges: [newEdge1, newEdge2], nodes: model.nodes };
+                droppedEdge.getController().fromModel(updateModel, true);
+              } else {
+                dropResult.appendChild(props.element);
+              }
+            }
+          }
+        })(DemoDefaultNode);
+      }
+      if (type === 'edge') {
+        return withDndDrop<Node, any, { droppable?: boolean; hover?: boolean; canDrop?: boolean }, ElementProps>({
+          accept: 'test',
+          canDrop: (item, monitor, props) =>
+            !!props &&
+            (props.element as Edge).getSource().getId() !== item.getId() &&
+            (props.element as Edge).getTarget().getId() !== item.getId(),
+          collect: (monitor) => ({
+            droppable: monitor.isDragging(),
+            dropTarget: monitor.isOver(),
+            canDrop: monitor.canDrop()
+          })
+        })(DefaultEdge);
+      }
+      return undefined;
+    }, [])
+  );
+  useModel(
+    React.useMemo(
+      (): Model => ({
+        graph: {
+          id: 'g1',
+          type: 'graph'
+        },
+        nodes: [
+          {
+            id: 'gr1',
+            type: 'group-drop',
+            group: true,
+            children: ['n2', 'n3'],
+            style: {
+              padding: 10
+            }
+          },
+          {
+            id: 'gr2',
+            type: 'group-drop',
+            group: true,
+            children: ['n4', 'n5'],
+            style: {
+              padding: 10
+            }
+          },
+          {
+            id: 'n1',
+            type: 'node-drag',
+            x: 50,
+            y: 50,
+            width: 30,
+            height: 30
+          },
+          {
+            id: 'n2',
+            type: 'node',
+            x: 200,
+            y: 20,
+            width: 10,
+            height: 10
+          },
+          {
+            id: 'n3',
+            type: 'node',
+            x: 150,
+            y: 100,
+            width: 20,
+            height: 20
+          },
+          {
+            id: 'n4',
+            type: 'node',
+            x: 300,
+            y: 250,
+            width: 30,
+            height: 30
+          },
+          {
+            id: 'n5',
+            type: 'node',
+            x: 350,
+            y: 370,
+            width: 15,
+            height: 15
+          }
+        ],
+        edges: [
+          {
+            id: 'e1',
+            type: 'edge',
+            source: 'n2',
+            target: 'n4'
+          }
+        ]
+      }),
+      []
+    )
+  );
+  return null;
+});
+
 export const DragAndDrop: React.FunctionComponent = () => {
   const [activeKey, setActiveKey] = React.useState<string | number>(0);
 
@@ -269,6 +432,9 @@ export const DragAndDrop: React.FunctionComponent = () => {
         </Tab>
         <Tab eventKey={1} title={<TabTitleText>Dnd Shift Regroup</TabTitleText>}>
           <DndShiftRegroup />
+        </Tab>
+        <Tab eventKey={2} title={<TabTitleText>Dnd Edges</TabTitleText>}>
+          <DndEdges />
         </Tab>
       </Tabs>
     </div>

--- a/packages/module/src/components/factories/components/componentUtils.ts
+++ b/packages/module/src/components/factories/components/componentUtils.ts
@@ -278,6 +278,20 @@ const edgeDragSourceSpec = (
   })
 });
 
+const edgeDropTargetSpec: DropTargetSpec<any, any, { droppable: boolean; dropTarget: boolean; canDrop: boolean }, any> =
+  {
+    accept: [NODE_DRAG_TYPE],
+    canDrop: (item, monitor, props) =>
+      !!props &&
+      (props.element as Edge).getSource().getId() !== item.id &&
+      (props.element as Edge).getTarget().getId() !== item.id,
+    collect: (monitor) => ({
+      droppable: monitor.isDragging(),
+      dropTarget: monitor.isOver(),
+      canDrop: monitor.canDrop()
+    })
+  };
+
 const noDropTargetSpec: DropTargetSpec<GraphElement, any, {}, { element: GraphElement }> = {
   accept: [NODE_DRAG_TYPE, EDGE_DRAG_TYPE, CREATE_CONNECTOR_DROP_TYPE],
   canDrop: () => false
@@ -291,6 +305,7 @@ export {
   graphDropTargetSpec,
   groupDropTargetSpec,
   edgeDragSourceSpec,
+  edgeDropTargetSpec,
   noDropTargetSpec,
   REGROUP_OPERATION,
   MOVE_CONNECTOR_DROP_TYPE,

--- a/packages/module/src/css/topology-components.css
+++ b/packages/module/src/css/topology-components.css
@@ -155,6 +155,8 @@
   --pf-topology__edge--InteractiveStroke: var(--pf-t--global--border--color--brand--default);
   --pf-topology__edge--m-selected--background--Stroke: var(--pf-topology__edge--ActiveStroke);
   --pf-topology__edge--m-selected--background--Opacity: 0.3;
+  --pf-topology__edge--m-drop-target--Stroke: var(--pf-t--global--border--color--brand--default);
+  --pf-topology__edge--m-drop-target--StrokeWidth: var(--pf-t--global--border--width--strong);
 
   --pf-topology__edge--m-info--EdgeStroke: var(--pf-t--global--border--color--brand--default);
   --pf-topology__edge--m-success--EdgeStroke: var(--pf-t--global--border--color--status--success--default);
@@ -705,6 +707,14 @@
 .pf-topology__edge__link.pf-m-dashed-xl {
   stroke-dasharray: 32 2;
   stroke-dashoffset: 34;
+}
+
+.pf-topology__edge__link.pf-m-drop-target {
+  stroke-dasharray: 2;
+  stroke-dashoffset: 2;
+  stroke: var(--pf-t--global--border--color--hover);
+  stroke-width: var(--pf-t--global--border--width--strong);
+
 }
 
 @keyframes pf-topology__edge__dash {


### PR DESCRIPTION
## What
Closes [Topology - Enable DefaultEdge as drop target](https://github.com/patternfly/react-topology/issues/259)

## Description
Adds parameters and styles to `DefaultEdge` for drop target indication.
Adds `edgeDropTargetSpec`
Updates the demo app to demo the new feature

## Type of change
- [x] Feature

## Screen shots / Gifs for design review
![DroppableEdgeDemo](https://github.com/user-attachments/assets/273ab519-9ad0-4827-a7c6-2b1f38d5a05e)


