### PR TITLE
fix(DefaultNode): Fix label flicker on hover

### DIFF
--- a/packages/module/src/components/nodes/DefaultNode.tsx
+++ b/packages/module/src/components/nodes/DefaultNode.tsx
@@ -174,7 +174,9 @@ const DefaultNodeInner: React.FunctionComponent<DefaultNodeInnerProps> = observe
     raiseLabelOnHover = true,
     hideContextMenuKebab
   }) => {
-    const [hovered, hoverRef] = useHover();
+    const [nodeHovered, hoverRef] = useHover();
+    const [labelHovered, labelRef] = useHover();
+    const hovered = nodeHovered || labelHovered;
     const status = nodeStatus || element.getNodeStatus();
     const refs = useCombineRefs<SVGEllipseElement>(hoverRef, dragNodeRef);
     const { width, height } = element.getDimensions();
@@ -348,6 +350,7 @@ const DefaultNodeInner: React.FunctionComponent<DefaultNodeInnerProps> = observe
 
       const nodeLabel = (
         <g
+          ref={labelRef}
           transform={
             raiseLabelOnHover && isHover
               ? `${scaleNode ? `translate(${translateX}, ${translateY})` : ''} scale(${nodeScale})`


### PR DESCRIPTION
## What
Closes #292

## Description
Fixes an issue where the node label flickers on hover and leaving the label after hovering does not remove the hover treatment.
Added a hover check for the label on DefaultNode to specifically watch the hover state on the label.

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review
![Kapture 2025-09-25 at 11 09 17](https://github.com/user-attachments/assets/cb29ac2b-b40f-46c0-b7e1-277e5e50c22a)


