### PR TITLE
fix: support for high contrast

### DIFF
--- a/packages/module/src/css/topology-components.css
+++ b/packages/module/src/css/topology-components.css
@@ -125,15 +125,19 @@
   --pf-topology__group--m-selected--topology__group__background--Fill: var(--pf-t--global--background--color--secondary--default);
 
   --pf-topology__group__background--Fill: var(--pf-t--global--background--color--secondary--default);
-  --pf-topology__group__background--Stroke: var(--pf-t--global--border--color--default);
-  --pf-topology__group__background--StrokeWidth: 5px;
+  --pf-topology__group__background--Stroke: var(--pf-t--global--border--color--main--default);
+  --pf-topology__group__background--StrokeWidth--base: var(--pf-t--global--border--width--extra-strong);
+  --pf-topology__group__background--StrokeWidth: var(--pf-topology__group__background--StrokeWidth--base);
 
   --pf-topology__group--m-alt-group--topology__group__background--Fill: var(--pf-t--global--background--color--primary--default);
   --pf-topology__group--m-alt-group--topology__group__background--Stroke: var(--pf-t--global--border--color--default);
 
   --pf-topology__group--m-selected--topology__group__background--Stroke: var(--pf-t--global--border--color--clicked);
+  --pf-topology__group--m-selected--topology__group__background--StrokeWidth: calc(var(--pf-topology__group__background--StrokeWidth--base) + var(--pf-t--global--border--width--high-contrast--strong));
   --pf-topology__group--m-hover--topology__group__background--Stroke: var(--pf-t--global--border--color--hover);
+  --pf-topology__group--m-hover--topology__group__background--StrokeWidth: calc(var(--pf-topology__group__background--StrokeWidth--base) + var(--pf-t--global--border--width--high-contrast--regular));
   --pf-topology__group--m-selected--m-hover--topology__group__background--Stroke: var(--pf-t--global--border--color--hover);
+  --pf-topology__group--m-selected--m-hover--topology__group__background--StrokeWidth: calc(var(--pf-topology__group__background--StrokeWidth--base) + var(--pf-t--global--border--width--high-contrast--regular));
   --pf-topology__group--m-drop-target--topology__group__background--Fill: var(--pf-t--global--color--nonstatus--blue--default);
   --pf-topology__group--m-drop-target--topology__group__background--Stroke: var(--pf-t--global--border--color--brand--default);
   --pf-topology__group__collapsed-badge__node__label__badge__rect--Fill: var(--pf-t--global--background--color--floating--default);
@@ -147,7 +151,7 @@
   --pf-topology__group--m-selected--group__label__node__label__background--Fill: var(--pf-t--global--color--brand--default);
 
   /* edge */
-  --pf-topology__edge--Stroke: #707070;
+  --pf-topology__edge--Stroke: var(--pf-t--global--border--color--on-secondary);
   --pf-topology__edge--StrokeWidth: var(--pf-t--global--border--width--regular);
   --pf-topology__edge--HoverStroke: var(--pf-topology__edge--Stroke);
   --pf-topology__edge--ActiveStroke: var(--pf-t--global--border--color--clicked);
@@ -577,16 +581,19 @@
 .pf-topology__group.pf-m-selected .pf-topology__group__background {
   --pf-topology__group__background--Fill: var(--pf-topology__group--m-selected--topology__group__background--Fill);
   --pf-topology__group__background--Stroke: var(--pf-topology__group--m-selected--topology__group__background--Stroke);
+  --pf-topology__group__background--StrokeWidth: var(--pf-topology__group--m-selected--topology__group__background--StrokeWidth);
 }
 
 .pf-topology__group.pf-m-hover .pf-topology__group__background {
   --pf-topology__group__background--Stroke: var(--pf-topology__group--m-hover--topology__group__background--Stroke);
+  --pf-topology__group__background--StrokeWidth: var(--pf-topology__group--m-hover--topology__group__background--StrokeWidth);
   --pf-topology__group__label__node__label__background--Stroke: var(--pf-topology__group--m-hover--topology__group__background--Stroke);
 }
 
 .pf-topology__group.pf-m-hover.pf-m-selected .pf-topology__group__background {
   --pf-topology__group__background--Fill: var(--pf-topology__group--m-selected--topology__group__background--Fill);
   --pf-topology__group__background--Stroke: var(--pf-topology__group--m-selected--m-hover--topology__group__background--Stroke);
+  --pf-topology__group__background--StrokeWidth: var(--pf-topology__group--m-selected--m-hover--topology__group__background--StrokeWidth);
   --pf-topology__group__label__node__label__background--Stroke: var(--pf-topology__group--m-selected--m-hover--topology__group__background--Stroke);
 }
 


### PR DESCRIPTION
## What
Closes https://github.com/patternfly/react-topology/issues/298

Preview link: https://react-topology-pr-topology-300.surge.sh/

To enable high contrast, you have to do it manually by adding the class `pf-v6-theme-high-contrast` to the document's `<html>` element.

## Description
* Updates default group stroke color to `border--color--main--default`
* Updates default group stroke width to `border--width--extra-strong` (3px)
  * I didn't see this called out explicitly (unless I missed it), but seems implied by the notes in figma to make the borders (3px default, x-strong + 1 hover, x-strong + 2 selected)
* Updates group hover stroke width to 4px in HC only
* Updates group selected stroke width to 5px in HC only
* Updates group hover + selected stroke width to 4px in HC only
* Updates edge stroke from `#707070` to `border--color--on-secondary`

Also updates the PF packages to latest prerelease, I imagine we'll remove that and bump to `6.4.0` here or in a separate PR once the PF release lands.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review


