### PR TITLE
fix: Renames About page to Overview to align with other nav items

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This package provides the resources necessary to use PatternFly Topology, an ope
 
 Topology utilizes some of PatternFly's React components https://github.com/patternfly/patternfly-react. 
 
-Documentation for Topology and its features is available on [the PatternFly website.](www.patternfly.org/topology/about-topology)
+Documentation for Topology and its features is available on [the PatternFly website.](www.patternfly.org/extensions/topology/overview)
 
 ## Table of contents
 

--- a/packages/module/patternfly-docs/content/examples/AboutTopology.md
+++ b/packages/module/patternfly-docs/content/examples/AboutTopology.md
@@ -1,5 +1,5 @@
 ---
-id: About Topology
+id: Overview
 section: extensions
 subsection: topology
 sortValue: 1


### PR DESCRIPTION
Part of https://github.com/patternfly/patternfly-org/issues/4753