### PR TITLE
fix(context-menu): render menu inline and use viewport coordinates

### DIFF
--- a/packages/module/src/behavior/withContextMenu.test.tsx
+++ b/packages/module/src/behavior/withContextMenu.test.tsx
@@ -1,0 +1,44 @@
+import { ReactNode } from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { WithContextMenuProps, withContextMenu } from './withContextMenu';
+
+let capturedReference: unknown;
+
+jest.mock('../components/contextmenu/ContextMenu', () => ({
+  __esModule: true,
+  default: ({ children, reference }: { children: ReactNode; reference: unknown }) => {
+    capturedReference = reference;
+    return <div data-testid="context-menu">{children}</div>;
+  }
+}));
+
+const WrappedComponent = ({ onContextMenu }: WithContextMenuProps) => (
+  <div data-testid="wrapped-node" onContextMenu={onContextMenu}>
+    Wrapped node
+  </div>
+);
+
+describe('withContextMenu', () => {
+  beforeEach(() => {
+    capturedReference = undefined;
+  });
+
+  it('should use viewport coordinates for point-based context menus', async () => {
+    const ComponentWithContextMenu = withContextMenu(() => [<div key="action">Action</div>])(WrappedComponent);
+
+    render(<ComponentWithContextMenu />);
+
+    await act(async () => {
+      fireEvent.contextMenu(screen.getByTestId('wrapped-node'), {
+        clientX: 120,
+        clientY: 140,
+        pageX: 420,
+        pageY: 540
+      });
+    });
+
+    expect(await screen.findByTestId('context-menu')).toBeInTheDocument();
+    expect(capturedReference).toEqual({ x: 120, y: 140 });
+  });
+});

--- a/packages/module/src/behavior/withContextMenu.tsx
+++ b/packages/module/src/behavior/withContextMenu.tsx
@@ -31,8 +31,8 @@ export const withContextMenu =
         setReference(
           atPoint
             ? {
-                x: e.pageX,
-                y: e.pageY
+                x: e.clientX,
+                y: e.clientY
               }
             : e.currentTarget
         );

--- a/packages/module/src/components/contextmenu/ContextMenu.test.tsx
+++ b/packages/module/src/components/contextmenu/ContextMenu.test.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import ContextMenu from './ContextMenu';
+import { ContextMenuItem } from './index';
+
+jest.mock('../popper/Popper', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div data-testid="mock-popper">{children}</div>
+}));
+
+describe('ContextMenu', () => {
+  it('should render menu items inside the topology popper and close on select', () => {
+    const onRequestClose = jest.fn();
+
+    render(
+      <ContextMenu reference={{ x: 120, y: 140 }} onRequestClose={onRequestClose}>
+        <ContextMenuItem>First</ContextMenuItem>
+      </ContextMenu>
+    );
+
+    expect(screen.getByTestId('mock-popper')).toBeInTheDocument();
+
+    const menuItem = screen.getByRole('menuitem', { name: 'First' });
+    fireEvent.click(menuItem);
+
+    expect(onRequestClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/module/src/components/contextmenu/ContextMenu.tsx
+++ b/packages/module/src/components/contextmenu/ContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { Dropdown } from '@patternfly/react-core';
+import { Menu, MenuContent } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import topologyStyles from '../../css/topology-components';
 // FIXME fully qualified due to the effect of long build times on storybook
@@ -35,14 +35,9 @@ const ContextMenu: React.FunctionComponent<ContextMenuProps> = ({
 
   return (
     <Popper {...other} closeOnEsc closeOnOutsideClick open={isOpen} onRequestClose={handleOnRequestClose}>
-      <Dropdown
-        onSelect={handleOnRequestClose}
-        toggle={() => <></>}
-        className={css(topologyStyles.topologyContextMenuCDropdownMenu)}
-        popperProps={{ appendTo: 'inline' }}
-      >
-        {children}
-      </Dropdown>
+      <Menu onSelect={handleOnRequestClose} className={css(topologyStyles.topologyContextMenuCDropdownMenu)}>
+        <MenuContent>{children}</MenuContent>
+      </Menu>
     </Popper>
   );
 };


### PR DESCRIPTION
## What
Closes #120 

## Description
This updates the topology context menu so it can flip correctly near the viewport edge.

The main change is that `ContextMenu` now renders a PatternFly `Menu` directly inside the topology popper instead of rendering a nested `Dropdown` with its own popper. This allows the outer topology popper to measure the actual menu height and position it correctly.

This PR also switches point-based context menu references in `withContextMenu` from `pageX/pageY` to `clientX/clientY`, which is consistent with viewport-based popper positioning.

## Root cause

The visible context menu was effectively wrapped in a second popper layer. Because of that, the outer topology popper did not have reliable dimensions for the real menu content, so bottom-edge flipping did not work as expected.

## Type of change
- [ X] Bugfix

## Screen shots / Gifs for design review
Before:
<img width="1611" height="1271" alt="image" src="https://github.com/user-attachments/assets/93197e53-9454-4797-81c4-c1ec81e52506" />
After:
<img width="1513" height="966" alt="image" src="https://github.com/user-attachments/assets/ab32f2db-cd42-4670-82b6-61adb6e79970" />

