### PR TITLE
chore(ci): update issue labeling and preview gating

### DIFF
--- a/.github/workflows/label-pf-team-issue.yml
+++ b/.github/workflows/label-pf-team-issue.yml
@@ -1,0 +1,9 @@
+name: Label PF Team issues
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label:
+    uses: patternfly/.github/.github/workflows/add-pf-team-label-workflow.yml@main
+    secrets: inherit

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,13 +1,22 @@
 name: pr-preview
-on: pull_request_target
+on:
+  pull_request_target:
+  issue_comment:
+    types: [created]
 jobs:
+  check-permissions:
+    uses: patternfly/.github/.github/workflows/check-team-membership.yml@main
+    secrets: inherit
+
   build-upload:
+    needs: check-permissions
+    if: needs.check-permissions.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     env:
       SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
       SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
       GH_PR_TOKEN: ${{ secrets.GH_PR_TOKEN }}
-      GH_PR_NUM: ${{ github.event.number }}
+      GH_PR_NUM: ${{ needs.check-permissions.outputs.pr-number }}
     steps:
       - uses: actions/checkout@v2
       # Yes, we really want to checkout the PR


### PR DESCRIPTION
Use org-level reusable workflows for new issue labeling and PR preview permission checks so deploy previews are restricted to trusted contributors.

Made-with: Cursor

