### PR TITLE
chore: cleans up workspace styles

### DIFF
--- a/packages/module/patternfly-docs/content/examples/topology-example.css
+++ b/packages/module/patternfly-docs/content/examples/topology-example.css
@@ -1,42 +1,13 @@
-[id^=ws-extensions-t-] {
-  margin: var(--pf-t--global--spacer--300);
+[id^=ws-extensions-e-] {
   height: 600px;
 }
+
 .pf-topology-visualization-surface {
-  border: 1px solid var(--pf-t--color--black);
+  border: 1px solid var(--pf-t--global--border--color--default);
 }
 
 @media (min-width: 768px) {
   .topology-example-sidebar.pf-topology-side-bar.shown {
     max-width: 300px;
   }
-}
-
-.pf-theme-dark .ws-extensions-t-about-topology,
-.pf-theme-dark .ws-extensions-t-anchors,
-.pf-theme-dark .ws-extensions-t-control-bar,
-.pf-theme-dark .ws-extensions-t-context-menu,
-.pf-theme-dark .ws-extensions-t-custom-edges,
-.pf-theme-dark .ws-extensions-t-custom-nodes,
-.pf-theme-dark .ws-extensions-t-layouts,
-.pf-theme-dark .ws-extensions-t-pan-and-zoom,
-.pf-theme-dark .ws-extensions-t-selection,
-.pf-theme-dark .ws-extensions-t-sidebar,
-.pf-theme-dark .ws-extensions-t-toolbar {
-  border: 1px solid var(--pf-t--color--gray--20);
-}
-
-.ws-extensions-t-topology .pf-v6-l-stack {
-  margin: -9px;
-  width: calc(100% + 18px);
-}
-
-.ws-extensions-t-topology .pf-topology-view__project-toolbar .pf-v6-c-dropdown>button {
-  justify-content: space-between;
-  width: 150px;
-}
-
-.ws-extensions-t-topology .topology-view-filter-dropdown>button {
-  justify-content: space-between;
-  width: 130px;
 }

--- a/packages/module/patternfly-docs/content/examples/topology-example.css
+++ b/packages/module/patternfly-docs/content/examples/topology-example.css
@@ -1,5 +1,10 @@
 [id^=ws-extensions-e-] {
   height: 600px;
+  margin: var(--pf-t--global--spacer--md);
+
+  .ws-example-page-wrapper & {
+    margin: 0;
+  }
 }
 
 .pf-topology-visualization-surface {


### PR DESCRIPTION
* Fixes short example height bug currently seen on org - https://www.patternfly.org/extensions/topology/custom-nodes/
* Removes a bunch of local workspace styles. Most were outdated but it does remove a margin that was around each example on the main examples page, but retains the margin on full page examples. Lemme know if you want to change anything with the border and/or margin.